### PR TITLE
Add native MCP (Model Context Protocol) server support — termux-native-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,43 @@ AI Agent --> POST /run {"cmd": "ls -la"} --> Termux-MCP --> Termux Shell
                       <-- chunked streaming output -+
 ```
 
+## Two commands — which do I run?
+
+| Command | What it is | When to use it |
+|---|---|---|
+| `termux-mcp` | REST API daemon on `:8080` (this README's endpoints) | Your existing scripts, apps and the Flutter app |
+| `termux-native-mcp` | **Native MCP server** (Model Context Protocol, spec 2025-06-18) | MCP clients: RikkaHub, desktop AI apps (Cursor, ...) |
+
+Both install together via `pkg install termux-mcp` and run as **separate
+processes** — starting `termux-native-mcp` never touches the REST daemon's
+port, state or behavior.
+
+```
+termux-mcp                  # REST API on 127.0.0.1:8080
+termux-native-mcp           # native MCP, Streamable HTTP on 127.0.0.1:8081
+termux-native-mcp --stdio   # native MCP over stdin/stdout (desktop clients)
+```
+
+RikkaHub (same phone):
+
+```json
+{
+  "type": "http",
+  "url": "http://127.0.0.1:8081/mcp",
+  "commonOptions": {
+    "name": "Termux",
+    "enable": true,
+    "headers": [["Authorization", "Bearer <TERMUX_MCP_AUTH_TOKEN>"]]
+  }
+}
+```
+
+Desktop MCP client (over ssh): `{"command": "ssh", "args": ["android", "termux-native-mcp", "--stdio"]}`
+
+Full guide, env vars and tool list: **[docs/mcp.md](docs/mcp.md)**.
+Both servers share the same safety system (risk gates, file snapshots,
+trash) because they run the same handler code.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ AI Agent --> POST /run {"cmd": "ls -la"} --> Termux-MCP --> Termux Shell
 
 ## Two commands — which do I run?
 
-| Command | What it is | When to use it |
-|---|---|---|
-| `termux-mcp` | REST API daemon on `:8080` (this README's endpoints) | Your existing scripts, apps and the Flutter app |
-| `termux-native-mcp` | **Native MCP server** (Model Context Protocol, spec 2025-06-18) | MCP clients: RikkaHub, desktop AI apps (Cursor, ...) |
+| Command | What it is |
+|---|---|
+| `termux-mcp` | REST API daemon on `:8080` (this README's endpoints) |
+| `termux-native-mcp` | **Native MCP server** (Model Context Protocol, spec 2025-06-18) for MCP clients: RikkaHub, desktop AI apps (Cursor, ...) |
 
 Both install together via `pkg install termux-mcp` and run as **separate
 processes** — starting `termux-native-mcp` never touches the REST daemon's

--- a/docs/mcp-support-design.md
+++ b/docs/mcp-support-design.md
@@ -1,0 +1,291 @@
+# Native MCP Support — Code Audit & Implementation Design
+
+**Issue:** termuxgpt/termux-mcp#3 — "Add native MCP (Model Context Protocol) server support"
+**Audit target:** `main` @ `dd812fe` (v0.9.0) — verified identical to `origin/main` (clean tree, 0/0 ahead/behind), so this audit covers the live release.
+**Constraint honored throughout:** zero changes to the working REST API. Every MCP component below is a *new* file or an *additive* packaging entry; no existing module is edited except `__main__.py`/`pyproject.toml` in the optional same-process phase, and those edits are behavior-neutral when MCP is not enabled.
+
+---
+
+## 1. Executive summary
+
+termux-mcp is **not an MCP server today** — it is a hand-rolled HTTP/WebSocket RPC server that *happens to be named* "mcp". Adding true MCP (JSON-RPC 2.0 over stdio and Streamable HTTP, per the 2025-06-18 spec) is very feasible **without touching the REST layer**, because:
+
+1. Every one of the ~110 HTTP endpoints funnels through two tiny primitives (`execute_streaming(handler, cmd)` in `shell.py` and `json_response(handler, status, data)` in `utils.py`) that only touch a 5-member HTTP surface (`send_response`, `send_header`, `end_headers`, `wfile`, `log_message`).
+2. The WebSocket transport (`websocket.py`, ~960 lines) is already a *second protocol* layered beside REST with per-connection state — it is the exact architectural precedent an MCP transport should follow.
+3. The OpenAI-format tool schemas in `tools_schema.py` are already JSON-Schema-compatible inside (`function.parameters`), so `tools/list` is mostly a re-shape, not a rewrite.
+
+**Recommended shape (option A from the issue):** dual-mode server — REST stays exactly as-is on port 8080; a Streamable-HTTP MCP endpoint runs on a *separate port* (`/mcp`), plus an optional stdio mode for desktop clients. MCP is **opt-in** (new env var / flag / console script), so the live service is untouched unless enabled.
+
+**Headline audit findings that shape the design** (details in §2):
+
+| # | Finding | Consequence for MCP |
+|---|---|---|
+| A1 | Tool logic exists in **two drifting copies**: REST handlers (`handler.py` + `handlers/*`) and WS builders (`websocket.py`). WS `delete` runs raw `rm -rf` (no trash), WS `write` takes **no snapshot** — the REST paths are the safe ones. | MCP must dispatch to the **REST handler layer**, never copy WS cmd-strings. |
+| A2 | HTTP "persistent `cd`" is per-**thread** and `ThreadingHTTPServer` spawns a fresh thread per request → `cd` does not actually persist across HTTP requests, and `/cancel` + `/env`'s `active_command_pid` can never work over HTTP (each request thread has its own empty thread-local). | MCP must use WS-style **per-session state** (own cwd, own pid, own kill flag), not the REST thread-local model. |
+| A3 | `OPENAI_TOOLS` lists **61** tools but the server routes ~110 endpoints, with stale duplicates (`camera` vs `camera_photo`, `wifi` vs `wifi_info`, `sms` vs `sms_send`, `tts` vs `tts_speak`, `ocr`; plus WS-only `session_*`, `history_*`). | MCP `tools/list` must expose a curated, unique set (clients choke on 100+ tools / token bloat). Define profiles. |
+| A4 | Every handler writes either chunked text (command output) or JSON, both with a distinctive HTTP shape. Success/error semantics are encoded in `❌ Exit code: N` / `✅ Done` markers and HTTP statuses. | MCP result mapping rules must decode these into `content` + `isError`. |
+| A5 | Confirmation flow is **client-round-trip** (`confirmed: true` re-send) — works fine over MCP because it's already an in-schema parameter. | Keep identical semantics; blocked = `isError`, confirmation-required = structured prompt to re-call. |
+| A6 | Risk gates (`security.py`), file safety (`safety.py`), auto-`-y`, output caps, `DEBIAN_FRONTEND` injection all live **inside** `execute_streaming`/`_run_process` and the handler bodies. | Reuse is automatic once dispatch targets the REST handler methods. |
+
+---
+
+## 2. Audit findings (full)
+
+### 2.1 Architecture map
+
+```
+__main__.run() ──► server.run()
+                    ├─ ThreadingHTTPServer(HOST:8080, MCPHandler)   [stdlib http.server, 1 thread/request]
+                    ├─ kill_port(8080)   network.py  (lsof kill + poll)
+                    └─ /ws route ─► websocket.ws_handler()           [hand-rolled RFC6455, per-conn state]
+MCPHandler.do_POST: ~110 path → method/router table
+   ├─ inline _handle_* methods  (handler.py)     ──► execute_streaming / json_response
+   └─ handlers/{terminal,features,ai_power,history}.py  (all take (handler, data))
+execute_streaming(handler, cmd)  shell.py
+   ├─ per-THREAD state: cwd, active_pid, pid_lock   (threading.local)
+   ├─ cd handling (persistent only per-thread)
+   ├─ preprocess: pkg/apt -y injection + DEBIAN_FRONTEND=noninteractive
+   ├─ Popen("export PAGER=cat; <cmd>", shell=True, setsid, cwd=tld.cwd)
+   ├─ optional timeout watchdog (TERMUX_MCP_TIMEOUT > 0)
+   ├─ line-loop → chunked HTTP frames, MAX_OUTPUT_BYTES cap + truncation marker
+   └─ trailing "❌ Exit code: N" / "✅ Done" markers
+safety.py: snapshot_before_write / trash_path / snapshot_targets_from_command   (used by /write,/delete,/run)
+security.py: get_risk_assessment → blocked / requires_confirmation
+websocket.py: per-connection {cwd, active_pid, killed Event, lock, send_lock}
+   _ws_execute_tool(tool, params, conn, req_id) → builds cmd strings AGAIN → _ws_run_process
+tools_schema.py: OPENAI_TOOLS (61, OpenAI "function" format) + build_catalog()
+```
+
+### 2.2 Safety model (the part MCP must inherit, not reimplement)
+
+- `security.py` — regex risk assessment: `DANGEROUS_PATTERNS` → hard block; `WARNING_PATTERNS` → `requires_confirmation`. Applied in `_handle_run` only (and per-handler path checks).
+- `utils.is_safe_path` — canonical-path block of `/dev/ /proc/ /sys/`; applied by file handlers.
+- `safety.py` — writes: `snapshot_before_write` copies the target to `~/termuxGPT/snapshots/<ts>/` and *echoes the snapshot path* so the AI can restore; deletes move to `~/termuxGPT/trash/`; `/run` gets a best-effort `snapshot_targets_from_command` scan (redirects, tee, sed -i, cp/mv, truncate, dd of=) prepended as an echo hint.
+- Output cap `MAX_OUTPUT_BYTES` (20 KB default) with truncation marker; auto-yes only for install commands; `preexec_fn=os.setsid` so children are killable process groups.
+
+**Audit finding (security drift):** the WS tool layer **bypasses** trash/snapshot — WS `delete` executes raw `rm -rf` (`websocket.py:388`), WS `write` overwrites without snapshot (`websocket.py:371`), and WS applies none of `security.py`'s risk gates. This drift is exactly what an MCP layer must not copy. (Recommendation for a *later* cleanup issue: delete the WS cmd-string builders and route WS through the same handler layer.)
+
+### 2.3 State model — where REST is weakest
+
+`shell.py` keeps cwd/active-pid in `threading.local`. Under `ThreadingMixIn` every request is a brand-new thread, so:
+
+- `cd ~/foo` sets the *current request thread's* cwd, then vanishes. The README/tool-schema claim "persistent cd state" is effectively untrue over HTTP; clients work around it with `cd x && cmd` chains.
+- `POST /cancel` runs `cancel_active()` on its own fresh thread → `active_pid` is `None` → **`/cancel` always returns `{"cancelled": false}` over HTTP.** Same for `/env`'s `active_command_pid` (always null). WS is unaffected (per-connection state + frame-loop cancel).
+- WS `cd`/cancel work correctly because state lives in a `conn` dict threaded through the executor.
+
+MCP must adopt the WS model (§4.3) — which also makes MCP strictly better than REST for `cd` persistence.
+
+### 2.4 Tool catalog
+
+- ~110 routed endpoints vs 61 `OPENAI_TOOLS` (curated subset, OpenAI `function` wrapper: `{type:"function", function:{name, description, parameters:{type:object, properties, required}}}`). `function.parameters` is already valid JSON Schema (minus `additionalProperties`).
+- Duplicates and naming collisions exist between REST-era names and WS-era names (see A3). The `build_catalog()` helper flattens to `{name, desc, params, category}` — evidence the author already cares about prompt/token economy.
+
+### 2.5 Compatibility facts (checked against the live spec, 2025-06-18)
+
+- stdio transport: messages are **newline-delimited JSON-RPC** on stdin/stdout; stderr for logs; nothing but MCP messages on stdout.
+- Streamable HTTP: **one endpoint** (e.g. `/mcp`) serving POST (client→server; may reply `application/json` or open an SSE stream via `Accept: text/event-stream`) and GET (server→client SSE stream). `Mcp-Session-Id` header issued at initialize; `MCP-Protocol-Version` header honored (absent ⇒ assume 2025-03-26). Origin validation is a spec **MUST** (DNS rebinding); loopback binding + auth recommended.
+- Lifecycle: `initialize` (version negotiation, capabilities) → client `notifications/initialized` → `tools/list` / `tools/call`; JSON-RPC errors −32700/−32600/−32601/−32602/−32603; `ping`; tool execution failures are `isError: true` results, not JSON-RPC errors.
+- RikkaHub (the client named in the issue): network transports only (SSE + Streamable HTTP), Bearer via `headers: [["Authorization","Bearer …"]]`, per-tool approval toggles. **Stdio is irrelevant for RikkaHub** — HTTP transport is the primary deliverable; stdio is a bonus for desktop clients (Claude Desktop via SSH/ADB port-forward).
+
+---
+
+## 3. Design
+
+### 3.1 Principles
+
+1. **Zero-touch REST**: existing modules are read-only inputs. All new behavior lives in new files. Any edit to existing files must be behavior-neutral when MCP is disabled (verified by running the old suite + manual smoke tests).
+2. **Dispatch to the safe layer**: every MCP tool call that has a REST handler runs that *handler* (risk gates, snapshots, trash, auto-yes, caps for free). No third copy of command builders.
+3. **WS-style session state**: each MCP session = `{cwd, active_pid, killed, lock}` like `websocket.py`'s `conn`, which fixes A2 for MCP.
+4. **Stdlib-only** (project has zero runtime deps; pip on-device is a real cost). Hand-rolled JSON-RPC mirrors the existing hand-rolled WebSocket — ~350 lines for transport. (Official `mcp` SDK remains the fallback if spec surface grows; see §7.)
+5. **Opt-in**: MCP disabled by default ⇒ live behavior bit-identical.
+
+### 3.2 Transports
+
+| Transport | Endpoint/IO | Purpose |
+|---|---|---|
+| Streamable HTTP (2025-06-18) | `POST/GET http://127.0.0.1:8081/mcp` | **Primary** — RikkaHub & any network MCP client. SSE streams for long `tools/call`. |
+| stdio | stdin/stdout, NDJSON | Desktop AI apps (Claude Desktop, Cursor…) that spawn `termux-native-mcp --stdio` via ADB/SSH `-R`. |
+
+- Old 2024-11-05 HTTP+SSE (`/sse` + `/messages`) is **not** needed: RikkaHub supports Streamable HTTP directly (per its docs, streamable is "the newer, recommended transport"); if a legacy client shows up, that transport is ~80 extra lines behind the same dispatcher — defer.
+- **Command naming** (settled): the REST server keeps `termux-mcp` exactly as today. The native MCP server is a *separate binary* `termux-native-mcp` (same package, new console-script entry): bare invocation = Streamable HTTP on `127.0.0.1:8081`; `--stdio` = stdio mode; `--port N` overrides the port. REST's `termux-mcp` startup log prints one hint line — `Native MCP server: run 'termux-native-mcp'` (a log string; no behavior change).
+- Default MCP port `8081` (env `TERMUX_NATIVE_MCP_PORT`). Host defaults to `127.0.0.1` and non-loopback **requires** auth, mirroring REST's rule in `server.py:33`.
+
+### 3.3 Protocol surface (v1)
+
+- `initialize` → `{protocolVersion: "2025-06-18" (or min(client, latest)), capabilities: {tools: {}, logging?}, serverInfo: {name: "termux-native-mcp", version: 0.9.x}, instructions: brief "runs shell commands on this Android device; files under ~/termuxGPT are safety snapshots/trash"}`
+- `notifications/initialized`, `ping`, `tools/list` (cursor optional — return everything in one page ≤ ~64 tools, see §3.5), `tools/call`.
+- Server notifications (HTTP mode): `notifications/progress` when the client passed `_meta.progressToken` on a long `tools/call` (spec-supported; cheap since the executor already sees lines).
+- v1 deliberately omits: `resources`, `prompts`, `completions`, `logging` (nice-to-have phase 2 — filesystem resources could expose `~/storage` read-only later), `tools/listChanged` (static list).
+- Session mgmt (HTTP): `Mcp-Session-Id` (UUID) issued on initialize result; honored/required afterwards (400 without, 404 when expired); `DELETE /mcp` tears the session down (kill running command, drop state); idle sessions expire after a configurable TTL (default 30 min) — **no TTL kill of running commands**, only of idle state.
+
+### 3.4 Security (spec MUSTs + project norms)
+
+- **Origin validation** on all MCP HTTP requests: allowlist env `TERMUX_NATIVE_MCP_ORIGIN` (comma-separated); if unset, loopback-only default behavior + no `Origin` header accepted from non-loopback bindings. Spec's DNS-rebinding MUST.
+- **Auth**: reuse the same `TERMUX_MCP_AUTH_TOKEN` scheme as REST (constant-time compare, `handler.py:50`): `Authorization: Bearer` on every MCP HTTP request, plus `?token=` for stdio-less clients is not applicable (stdio inherits the parent process's environment — client must set the env var; document that).
+- Non-loopback bind ⇒ auth mandatory (mirror `server.py:33`); MCP **never** binds `0.0.0.0` by default.
+- Every shell path still passes `security.py` + `safety.py` because dispatch reuses handlers (§3.6). No bypass parameters accepted; `confirmed` only unlocks *confirmation*-level risks, exactly as REST.
+
+### 3.5 Tool exposure
+
+Single MCP endpoint exposing **one curated tool list** (not all ~110). Source of truth: new `MCP_TOOL_ROUTES` table in the bridge module mapping **unique tool name → REST handler method + input-schema**:
+
+- Take `OPENAI_TOOLS`, drop WS-era duplicates (`camera→camera_photo`, `wifi→wifi_info`, `sms→sms_send`, `tts→tts_speak`, `ocr→text_extract`), drop REST-doc'd endpoints with no schema entry **that matter** are *added* deliberately only if safe & small (e.g. `text_extract`, `db_query`, `translate`, `git_op`, `patch`, `web_server` — explicit decision per tool; default keeps the list ≈ 61).
+- Add MCP-native tools that have no REST equivalent but solve MCP's long-run problem:
+  - `session_start` / `session_run` / `session_poll` / `session_list` / `session_kill` (tmux-backed, non-blocking — already proven in WS; the recommended way to run `pkg upgrade`-class jobs without holding a `tools/call` open). State is **per-MCP-session**, fixing WS's shared `_ws_session` global.
+  - `cancel` (session-scoped pid + kill flag — the one tool MCP implements natively, because REST `/cancel` is broken per A2).
+- Filtering env `TERMUX_NATIVE_MCP_TOOLS` = comma list (or `-`-prefixed exclusions) for power users; default = curated list. Profile presets (`core`, `device`, `media`, `smart`, `devops`) map to the existing `build_catalog` categories — future nicety, schema carries a `category` extension only if clients ignore unknown fields (they do per spec `additionalProperties:false` rules — actually **no**: MCP requires strict schema compliance, so keep custom fields out of `inputSchema`; categories live server-side in config only).
+- Tool list order: curated manual order (most-used first: `run`, `ls`, `read`, `write`, …), not alphabetical — client context shows the first N.
+
+`tools/call` param mapping: MCP arguments object == REST JSON body (`{cmd}`, `{path, content}`…). Camel/snake already aligned. The `detailed`/`bare` bool quirks are inherited as-is (documented drift between schema and handler for `ls`: schema says `detailed`, handler reads `bare`/`no_dotfiles` — **fix in bridge by normalizing**, i.e. accept `bare`/`no_dotfiles` and map `detailed`→`-la` default behavior; see open questions).
+
+### 3.6 Dispatch: the virtual-handler bridge (zero-duplication reuse)
+
+All REST handlers only use the 5-member HTTP surface + `json_response`. So:
+
+```python
+class VirtualHandler:                 # NEW: mcp_bridge.py
+    """Presents the BaseHTTPRequestHandler surface; captures everything.
+    wfile collects raw bytes (chunked framing included); headers & status
+    are recorded, not sent."""
+    def send_response(self, status, *a): self.status = status
+    def send_header(self, k, v): self.headers_out.append((k, v))
+    def end_headers(self): self._chunked = ("Transfer-Encoding","chunked") in pairs
+    wfile = CapturingWriter  # .write/.flush append to buffer
+```
+
+Dispatch procedure per `tools/call`:
+
+1. Resolve `MCP_TOOL_ROUTES[name]` → handler callable + `handler`-surface mode.
+2. Session worker **seeds the thread-local** before invoking: `set_current_dir(session["cwd"])` (fixes A2 — handler code and `execute_streaming` read tld transparently), and reads it back afterwards into `session["cwd"]` so `cd` persists per MCP session. (Per-request threads make this safe; no REST code is affected.)
+3. Call `handler(virtual, params_dict)` synchronously.
+4. Decode captured response → MCP result:
+   - **chunked text** (`Transfer-Encoding: chunked`): de-chunk (strip length frames) → output text. Parse terminal markers → `isError` (`❌ Exit code: N` ≠ 0 or `⏱️ Timed out`), strip the marker line from content, keep truncation marker verbatim.
+   - **JSON** (`application/json`): parse body. If `requires_confirmation: true` ⇒ result text = the same message the REST client sees + instruction "re-invoke with `confirmed: true`", `isError: false` (mirrors REST 200). If `blocked`/`error`/status ≥ 400 ⇒ `isError: true` with the error text.
+   - Status 400/403 already emitted as JSON by handlers — same rule as above.
+5. Wrap result as `{"content": [{"type": "text", "text": …}], "isError": …}`. (Structured JSON passthrough for JSON tools is a v1.1 option — `structuredContent` support is inconsistent across clients; text-first is safest.)
+
+Tools without a REST handler but natively implemented (see §3.5) bypass the virtual handler and call the WS-style executor directly. **`run` is native too** (implemented, not bridged): it needs session `cd` + working `cancel`, and it calls the exact same primitives the REST handler uses (`get_risk_assessment`, `snapshot_targets_from_command`, `preprocess`, auto-yes, output caps), so the gates are identical. Every other tool with a REST handler dispatches through the VirtualHandler (snapshot/trash parity included).
+
+### 3.7 Long-running commands & streaming over MCP
+
+- MCP has no mid-call output streaming — a `tools/call` returns when done. Two sanctioned patterns:
+  1. **Progress notifications**: if the client sent `params._meta.progressToken`, the executor emits `notifications/progress` per output line (HTTP: over the GET SSE stream or the POST's SSE response; stdio: as NDJSON lines). Client shows "running…".
+  2. **tmux sessions** (`session_run`/`session_poll`, §3.5): fire-and-forget + poll — the pattern WS already shipped (v0.8.3) precisely because HTTP couldn't hold calls open.
+- Output cap & no-timeout default carry over unchanged (MCP inherits `MAX_OUTPUT_BYTES`/`TERMUX_MCP_TIMEOUT` semantics via the bridge). Client-side request timeouts are the client's problem; `session_*` + cancel are the answer, and are documented in `instructions`.
+
+### 3.8 Configuration (all new, all opt-in; names follow the binary)
+
+| Env var / flag | Default | Meaning |
+|---|---|---|
+| `TERMUX_NATIVE_MCP_PORT` | `8081` | MCP Streamable-HTTP port (`0`/unset with the REST daemon = MCP disabled) |
+| `--port N` | — | CLI override of the above |
+| `TERMUX_NATIVE_MCP_HOST` | `127.0.0.1` | bind; non-loopback ⇒ auth required |
+| `TERMUX_NATIVE_MCP_ORIGIN` | (empty = loopback) | allowed `Origin` values, comma-separated |
+| `TERMUX_NATIVE_MCP_TOOLS` | (curated list) | include/exclude filters |
+| `TERMUX_NATIVE_MCP_SESSION_TTL` | `1800` | idle session expiry seconds |
+| `--stdio` | HTTP mode | run stdio mode instead of HTTP |
+
+Auth: `TERMUX_NATIVE_MCP_AUTH_TOKEN` if set, else fall back to the shared `TERMUX_MCP_AUTH_TOKEN` (one secret for both servers). REST vars (`PORT`, `MAX_OUTPUT`, `TIMEOUT`) keep their meaning and are not consulted by the native server.
+
+---
+
+## 4. Implementation plan (file-by-file)
+
+### Phase 0 — nothing to do: baseline
+
+Freeze `main` at v0.9.0; note SHA `dd812fe`. All work on `feature/mcp`.
+
+### Phase 1 — new modules (no edits to live files)
+
+| New file | Contents | Est. size |
+|---|---|---|
+| `termux_mcp/mcp_config.py` | lazy env reads: `TERMUX_NATIVE_MCP_*` (+ auth fallback to `TERMUX_MCP_AUTH_TOKEN`), protocol constants | ~55 |
+| `termux_mcp/mcp_bridge.py` | `VirtualHandler`, `CapturingWriter`, chunk de-framer, route table (name → handler), schema re-shape (`OPENAI_TOOLS` → MCP `tools/list` items), result-decode rules (§3.6), tool filter logic | ~326 |
+| `termux_mcp/mcp_core.py` | MCP session type (WS-style `{cwd, pid, killed, lock, closed}`), session registry + TTL, JSON-RPC dispatch, native executors for `run`/`cancel`/`session_*` (same risk/safety primitives as REST), progress-notification hook | ~568 |
+| `termux_mcp/mcp_transport_http.py` | Streamable-HTTP endpoint on `ThreadingHTTPServer`: POST handler (JSON-RPC → reply `application/json` or SSE), GET SSE stream per session, `Mcp-Session-Id` issuance/validation, `MCP-Protocol-Version` negotiation, Origin check, Bearer auth, `DELETE`, 404/400 semantics per spec | ~300 |
+| `termux_mcp/mcp_transport_stdio.py` | NDJSON read loop on stdin → dispatch → NDJSON on stdout; stderr logging; same session/cancel semantics (single session; cwd persists process-lifetime) | ~120 |
+| `termux_mcp/mcp_server.py` | `run_http()`, `run_stdio()` (and optional later `run_dual()`); reuse `server.py` guard logic patterns (auth length check, loopback rule) by **importing** from `.config`/`.security` only | ~80 |
+| `termux_mcp/mcp_main.py` | CLI entry: `argparse` for `--stdio` / `--port`, env dispatch → `run_http()` / `run_stdio()`; the `termux-native-mcp` console-script target | ~40 |
+| `tests/test_mcp_bridge.py`, `tests/test_mcp_core.py`, `tests/test_mcp_http.py` | stdlib `unittest` — 51 tests: dechunk/marker decoding, registry integrity, schema validation, risk gates (no execution), session TTL, stdio loop, live HTTP transport (ephemeral port) | ~614 |
+| `docs/mcp.md` | user-facing: RikkaHub config JSON, curl smoke tests, Claude Desktop stdio sample, env table | ~120 |
+
+### Phase 2 — additive packaging (the only edits, and they're opt-in)
+
+- `pyproject.toml`: add a second `[project.scripts]` entry — `termux-native-mcp = "termux_mcp.mcp_main:main"` — next to the untouched `termux-mcp = "termux_mcp.__main__:run"`. `pkg install termux-mcp` installs both commands; the REST console script is unchanged and still boots REST only.
+- Version bump → 0.10.0 (semver: additive feature).
+- README: new "MCP support" section with a "which command do I run?" table (`termux-mcp` = REST daemon · `termux-native-mcp` = native MCP server); **existing** docs untouched.
+- Optional later convenience (NOT in v1): an in-process dual daemon (`TERMUX_MCP_NATIVE_PORT`-style guard in `__main__.py`, dead code when unset). v1 ships the separate `termux-native-mcp` process → zero edits to `__main__.py`/`server.py`, strongest isolation.
+
+### Phase 3 — verification (no live impact)
+
+1. **Unit**: bridge decode rules (chunked/JSON/statuses/markers), schema re-shape, filter logic, session TTL/cancel.
+2. **Integration on the phone** (or Windows shell with a fake `HOME`): start MCP port with the live REST server running on 8080; run official-spec smoke client:
+   - `initialize` → session header; `tools/list` (≤ N tools, all schema-valid); `tools/call run {cmd: "cd /sdcard && pwd"}` then a second call asserting **cwd persisted** (proves MCP fixes A2); `tools/call delete` without `confirmed` (expects confirmation text), with `confirmed` (expects trash path echo); `write` then `ls ~/termuxGPT/snapshots` (snapshot exists); risk-blocked command (`rm -rf ~`) ⇒ `isError` with block message.
+3. **RikkaHub on-device**: add server `{"type":"http", url:"http://127.0.0.1:8081/mcp", commonOptions:{headers:[["Authorization","Bearer <token>"]]}}`; exercise a shell tool + a session tool.
+4. **Regression**: `curl /ping`, `/run`, `/write`, `/delete` on 8080 before/after MCP enabled — identical.
+5. Optionally CI: a workflow job running the unittest suite + a spec smoke script (existing `python-publish.yml` untouched).
+
+### Phase 4 — post-launch (separate issues, not part of #3)
+
+- Unify the three executors (REST `_run_process`, WS `_ws_run_process`, MCP executor) into one `runner` used by all transports — the drift (A1) becomes a single-source fix. Medium risk, big payoff; do on a branch after MCP ships.
+- Fix REST `/cancel` + `/env` `active_command_pid` (move REST to per-session state) — MCP's session model is the blueprint.
+- WS `delete`/`write` switch to trash/snapshot semantics (safety parity).
+- `resources` (read-only `~/storage`, device info) for filesystem-style MCP clients; `prompts`; legacy 2024-11-05 SSE if a client demands it.
+
+---
+
+## 5. Why this can't break the live version — checklist
+
+- [ ] No existing `.py` file is modified in the recommended path (separate-process mode).
+- [ ] MCP is off unless `termux-native-mcp` is invoked (REST daemon behavior untouched by its presence).
+- [ ] MCP binds its own port; never calls `network.kill_port` on 8080.
+- [ ] REST handler code executes only via `VirtualHandler` when MCP is on — no global mutation; thread-local cwd seeded per MCP call is read back before the thread dies (per-request threads make cross-talk impossible).
+- [ ] Import-time side effects: handlers/* already imported by `handler.py`; new modules import the same leaf modules only.
+- [ ] Auth: same constant-time compare; no new trust boundaries.
+- [ ] `tools/call` never accepts commands the REST layer would reject; `confirmed` semantics identical; snapshots/trash untouched.
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Spec drift in hand-rolled JSON-RPC | Conformance tests against the official client SDK (desktop) in CI; only 4 methods in v1; revisit SDK adoption if methods/resources grow (see below) |
+| 100+ tool schema bloat in client context | Curated ≈61-list default + filters + `session_*` replacement of long ops; order by usefulness |
+| Long `tools/call` hitting client timeouts | `session_*` non-blocking pattern + progress notifications; document in `instructions` |
+| HTTP clients holding SSE open forever | Per-request SSE lifecycle per spec (§3.2/5.3 of transport): close after response; session TTL; DELETE |
+| Two processes both killing port 8080 (`kill_port`) | MCP never touches REST's port; its own startup kills only its own port (same `kill_port` helper is fine) |
+| In-process dual mode thread interactions (tmux globals in `websocket.py`) | Phase-2 default = separate process; if in-process dual mode, MCP keeps **its own** session state, never `websocket._ws_session` |
+| AGPL compliance | New files carry the same header as existing; no copyleft issue with the MCP spec itself (open spec) |
+| `requires-python >= 3.8` vs `list[str]` annotations (3.9+) | Low severity (Termux ships 3.11/3.12); bump to `>=3.9` in the MCP release changelog |
+
+## 7. Decision points for the maintainer (open questions)
+
+1. **Hand-rolled stdio/HTTP (recommended, zero deps) vs official `mcp` SDK / FastMCP.** Hand-rolled fits this codebase's zero-dependency philosophy and its precedent (hand-rolled WebSocket, ~960 lines). SDK buys spec longevity + OAuth later, costs pip dependency on-device and API churn. **Recommendation: hand-rolled v1; SDK only if resources/prompts/auth explode.**
+2. **Binary layout** — **settled: separate `termux-native-mcp`** (own process, strongest isolation, zero live-file edits; bare = HTTP on 8081, `--stdio` for desktop clients). Revisit an in-process dual daemon only if users ask for one-process convenience later.
+3. **Tool list**: expose the curated 61 (recommended) or add long-tail REST tools (db-query, translate, git-op, …)? Default list should match what `build_catalog` calls "core" + session tools.
+4. **Tool naming**: keep current names verbatim (some are awkward: `camera_photo`, `text_extract` vs `ocr`) — changing breaks REST-schema parity; MCP can ship `aliases` in tool descriptions. Recommendation: keep names, alias descriptions.
+5. **`ls` param mismatch**: schema `detailed` vs handler `bare`/`no_dotfiles` — normalize in the bridge (`detailed: true` → `-l`+dotfiles, `bare: true` → `-1`), preserving REST behavior exactly on the REST side.
+6. **Progress notifications**: v1 optional if client sends `progressToken`; confirm RikkaHub forwards it (likely not — most clients don't). Default: session tools carry the load.
+7. **Version bump**: 0.10.0 + `protocolVersion` 2025-06-18. Confirm Termux Python ≥ 3.9 assumption holds for the package baseline.
+
+## 8. RikkaHub sample config (for the issue reply)
+
+```json
+{
+  "type": "http",
+  "url": "http://127.0.0.1:8081/mcp",
+  "commonOptions": {
+    "name": "Termux-MCP",
+    "enable": true,
+    "headers": [["Authorization", "Bearer <TERMUX_MCP_AUTH_TOKEN>"]]
+  }
+}
+```
+
+Claude Desktop (desktop, via ADB/SSH):
+```json
+{ "mcpServers": { "termux": { "command": "ssh", "args": ["android", "termux-native-mcp", "--stdio"] } } }
+```
+
+---
+
+*Audit & design prepared against `dd812fe` (v0.9.0, AGPL-3.0). No live code was modified in preparing this document.*

--- a/docs/mcp-support-design.md
+++ b/docs/mcp-support-design.md
@@ -85,7 +85,7 @@ MCP must adopt the WS model (§4.3) — which also makes MCP strictly better tha
 - stdio transport: messages are **newline-delimited JSON-RPC** on stdin/stdout; stderr for logs; nothing but MCP messages on stdout.
 - Streamable HTTP: **one endpoint** (e.g. `/mcp`) serving POST (client→server; may reply `application/json` or open an SSE stream via `Accept: text/event-stream`) and GET (server→client SSE stream). `Mcp-Session-Id` header issued at initialize; `MCP-Protocol-Version` header honored (absent ⇒ assume 2025-03-26). Origin validation is a spec **MUST** (DNS rebinding); loopback binding + auth recommended.
 - Lifecycle: `initialize` (version negotiation, capabilities) → client `notifications/initialized` → `tools/list` / `tools/call`; JSON-RPC errors −32700/−32600/−32601/−32602/−32603; `ping`; tool execution failures are `isError: true` results, not JSON-RPC errors.
-- RikkaHub (the client named in the issue): network transports only (SSE + Streamable HTTP), Bearer via `headers: [["Authorization","Bearer …"]]`, per-tool approval toggles. **Stdio is irrelevant for RikkaHub** — HTTP transport is the primary deliverable; stdio is a bonus for desktop clients (Claude Desktop via SSH/ADB port-forward).
+- RikkaHub (the client named in the issue): network transports only (SSE + Streamable HTTP), Bearer via `headers: [["Authorization","Bearer …"]]`, per-tool approval toggles. **Stdio is irrelevant for RikkaHub** — HTTP transport is the primary deliverable; stdio is a bonus for desktop clients via SSH/ADB port-forward.
 
 ---
 
@@ -104,7 +104,7 @@ MCP must adopt the WS model (§4.3) — which also makes MCP strictly better tha
 | Transport | Endpoint/IO | Purpose |
 |---|---|---|
 | Streamable HTTP (2025-06-18) | `POST/GET http://127.0.0.1:8081/mcp` | **Primary** — RikkaHub & any network MCP client. SSE streams for long `tools/call`. |
-| stdio | stdin/stdout, NDJSON | Desktop AI apps (Claude Desktop, Cursor…) that spawn `termux-native-mcp --stdio` via ADB/SSH `-R`. |
+| stdio | stdin/stdout, NDJSON | Desktop AI apps that spawn `termux-native-mcp --stdio` via ADB/SSH `-R`. |
 
 - Old 2024-11-05 HTTP+SSE (`/sse` + `/messages`) is **not** needed: RikkaHub supports Streamable HTTP directly (per its docs, streamable is "the newer, recommended transport"); if a legacy client shows up, that transport is ~80 extra lines behind the same dispatcher — defer.
 - **Command naming** (settled): the REST server keeps `termux-mcp` exactly as today. The native MCP server is a *separate binary* `termux-native-mcp` (same package, new console-script entry): bare invocation = Streamable HTTP on `127.0.0.1:8081`; `--stdio` = stdio mode; `--port N` overrides the port. REST's `termux-mcp` startup log prints one hint line — `Native MCP server: run 'termux-native-mcp'` (a log string; no behavior change).
@@ -207,7 +207,7 @@ Freeze `main` at v0.9.0; note SHA `dd812fe`. All work on `feature/mcp`.
 | `termux_mcp/mcp_server.py` | `run_http()`, `run_stdio()` (and optional later `run_dual()`); reuse `server.py` guard logic patterns (auth length check, loopback rule) by **importing** from `.config`/`.security` only | ~80 |
 | `termux_mcp/mcp_main.py` | CLI entry: `argparse` for `--stdio` / `--port`, env dispatch → `run_http()` / `run_stdio()`; the `termux-native-mcp` console-script target | ~40 |
 | `tests/test_mcp_bridge.py`, `tests/test_mcp_core.py`, `tests/test_mcp_http.py` | stdlib `unittest` — 51 tests: dechunk/marker decoding, registry integrity, schema validation, risk gates (no execution), session TTL, stdio loop, live HTTP transport (ephemeral port) | ~614 |
-| `docs/mcp.md` | user-facing: RikkaHub config JSON, curl smoke tests, Claude Desktop stdio sample, env table | ~120 |
+| `docs/mcp.md` | user-facing: RikkaHub config JSON, curl smoke tests, desktop-client stdio sample, env table | ~120 |
 
 ### Phase 2 — additive packaging (the only edits, and they're opt-in)
 
@@ -281,7 +281,7 @@ Freeze `main` at v0.9.0; note SHA `dd812fe`. All work on `feature/mcp`.
 }
 ```
 
-Claude Desktop (desktop, via ADB/SSH):
+Desktop MCP client (via ADB/SSH):
 ```json
 { "mcpServers": { "termux": { "command": "ssh", "args": ["android", "termux-native-mcp", "--stdio"] } } }
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,8 +7,8 @@ transports that MCP clients understand:
 
 * **Streamable HTTP** (default) — for [RikkaHub](https://rikkahub.me) and
   any network MCP client.
-* **stdio** — for desktop AI apps (Claude Desktop, Cursor, ...) that spawn
-  a command, usually over `ssh android`.
+* **stdio** — for desktop AI apps (Cursor, ...) that spawn a command,
+  usually over `ssh android`.
 
 Both commands are installed by the same `pkg install termux-mcp`. They are
 **independent processes** — running `termux-native-mcp` never touches the
@@ -44,7 +44,7 @@ RikkaHub → Add MCP server:
 (the `Authorization` header is only needed once you set a token — see
 below).
 
-## Quick start (Claude Desktop, from a computer)
+## Quick start (desktop client, from a computer)
 
 On the phone, make sure `sshd` runs (`pkg install openssh`). Then in the
 desktop client's MCP config:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,127 @@
+# Native MCP server (`termux-native-mcp`)
+
+`termux-native-mcp` speaks the **Model Context Protocol** (spec 2025-06-18)
+natively — no REST, no adapters. It exposes the same tool catalog and the
+same safety system as the REST API (`termux-mcp`), but through JSON-RPC
+transports that MCP clients understand:
+
+* **Streamable HTTP** (default) — for [RikkaHub](https://rikkahub.me) and
+  any network MCP client.
+* **stdio** — for desktop AI apps (Claude Desktop, Cursor, ...) that spawn
+  a command, usually over `ssh android`.
+
+Both commands are installed by the same `pkg install termux-mcp`. They are
+**independent processes** — running `termux-native-mcp` never touches the
+REST server's port, state, or behavior.
+
+```
+termux-mcp              REST API daemon on :8080   (unchanged, separate)
+termux-native-mcp       native MCP — Streamable HTTP on 127.0.0.1:8081
+termux-native-mcp --stdio   native MCP over stdin/stdout
+termux-native-mcp --port 9000 --host 0.0.0.0
+```
+
+## Quick start (RikkaHub, same phone)
+
+```bash
+termux-native-mcp
+```
+
+RikkaHub → Add MCP server:
+
+```json
+{
+  "type": "http",
+  "url": "http://127.0.0.1:8081/mcp",
+  "commonOptions": {
+    "name": "Termux",
+    "enable": true,
+    "headers": [["Authorization", "Bearer <your-token>"]]
+  }
+}
+```
+
+(the `Authorization` header is only needed once you set a token — see
+below).
+
+## Quick start (Claude Desktop, from a computer)
+
+On the phone, make sure `sshd` runs (`pkg install openssh`). Then in the
+desktop client's MCP config:
+
+```json
+{ "mcpServers": {
+    "termux": { "command": "ssh",
+                "args": ["android", "termux-native-mcp", "--stdio"] }
+} }
+```
+
+Verify the wire works before configuring a client:
+
+```bash
+curl -s http://127.0.0.1:8081/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+       "params":{"protocolVersion":"2025-06-18"}}'
+```
+
+## What you get
+
+57 tools (curated from the REST catalog, duplicates merged): shell `run`
+with persistent `cd` per session, filesystem with snapshot/trash safety,
+device & sensors via termux-api, media, cron, git, smart installs — plus
+MCP-native tools:
+
+| Tool | Why it exists |
+|---|---|
+| `run` | shell commands; `confirmed: true` acknowledges risk warnings |
+| `cancel` | kill the command currently running in your session |
+| `session_start` / `session_run` / `session_poll` / `session_list` / `session_kill` | long jobs (e.g. `pkg upgrade`) run in a tmux session: `session_run` returns immediately, `session_poll` fetches new output — don't hold a `tools/call` open for minutes |
+
+Every safety guarantee of the REST API carries over, because both servers
+run the same handler code: dangerous commands are blocked, risky ones need
+`confirmed: true`, file overwrites are snapshotted under
+`~/termuxGPT/snapshots/`, deletes move to `~/termuxGPT/trash/`.
+
+### Long-running commands
+
+A `tools/call` returns only when the command finishes. For anything long:
+
+1. `session_start`
+2. `session_run` `{cmd: "pkg upgrade"}`
+3. `session_poll` (repeat until `running: false`)
+
+If a client passes `_meta.progressToken` on a call, the server also emits
+`notifications/progress` with live output lines (up to 200 per call).
+
+## Configuration
+
+| Env var / flag | Default | Meaning |
+|---|---|---|
+| `TERMUX_NATIVE_MCP_PORT` / `--port` | `8081` | HTTP listen port |
+| `TERMUX_NATIVE_MCP_HOST` / `--host` | `127.0.0.1` | Bind address. Non-loopback **requires** an auth token. |
+| `TERMUX_NATIVE_MCP_AUTH_TOKEN` | (fallback `TERMUX_MCP_AUTH_TOKEN`) | Bearer token. ≥ 16 chars, refused otherwise. |
+| `TERMUX_NATIVE_MCP_PATH` | `/mcp` | MCP endpoint path |
+| `TERMUX_NATIVE_MCP_ORIGIN` | (empty) | Allowed `Origin` values, comma-separated (DNS-rebinding guard) |
+| `TERMUX_NATIVE_MCP_TOOLS` | (all) | Tool filter: `run,ls,-history` |
+| `TERMUX_NATIVE_MCP_SESSION_TTL` | `1800` | Idle HTTP session expiry (seconds) |
+| `--stdio` | — | stdio transport instead of HTTP |
+
+stdio mode inherits the launching process's environment: if auth is on,
+set `TERMUX_NATIVE_MCP_AUTH_TOKEN` for the ssh command too.
+
+## Security model
+
+* Bind loopback by default; non-loopback binding without an auth token
+  refuses to start (same rule as the REST server).
+* Bearer auth (constant-time compare) on every HTTP request, including the
+  SSE streams.
+* `Origin` validated against `TERMUX_NATIVE_MCP_ORIGIN`; with no allowlist
+  configured, Origins are only accepted on loopback connections.
+* Every request in a session carries `Mcp-Session-Id` (issued at
+  `initialize`); unknown/expired sessions get 404 so clients re-initialize.
+* Sessions expire after `TERMUX_NATIVE_MCP_SESSION_TTL` idle seconds;
+  running commands are never killed by TTL — only by `cancel`, session
+  DELETE, or server shutdown.
+* Same risk gates, path blocking (`/dev /proc /sys`), snapshots and trash
+  as the REST API — both servers share the handler layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "termux-mcp"
-version = "0.9.0"
-description = "Powerful MCP server for Termux — let AI agents run shell commands on your Android device in real time"
+version = "0.10.0"
+description = "Termux AI server: REST API daemon (termux-mcp) + native MCP server (termux-native-mcp) — let AI agents run shell commands on your Android device in real time"
 readme = "README.md"
 license = {text = "AGPL-3.0"}
 classifiers = [
@@ -16,3 +16,4 @@ requires-python = ">=3.8"
 
 [project.scripts]
 termux-mcp = "termux_mcp.__main__:run"
+termux-native-mcp = "termux_mcp.mcp_main:main"

--- a/termux_mcp/mcp_bridge.py
+++ b/termux_mcp/mcp_bridge.py
@@ -1,0 +1,326 @@
+import json
+import logging
+import re
+from typing import List, Optional
+
+
+from .config import MAX_OUTPUT_BYTES
+from .handler import MCPHandler
+from .handlers.ai_power import handle_smart_install, handle_optimize
+from .handlers.features import (
+    handle_system_info, handle_process_list, handle_process_kill,
+    handle_cron_add, handle_cron_list, handle_cron_remove,
+    handle_diff, handle_health, handle_cloud_sync, handle_git_pr,
+    handle_recipe_list, handle_recipe_run, handle_recipe_save,
+    handle_context, handle_context_save,
+)
+from .handlers.history import (
+    handle_history_list, handle_history_save, handle_history_clear,
+)
+from .handlers.terminal import (
+    handle_diagnose, handle_backup, handle_restore,
+)
+from .tools_schema import OPENAI_TOOLS
+
+
+logger = logging.getLogger(__name__)
+
+
+class CapturingWriter:
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data) -> int:
+        if isinstance(data, str):
+            data = data.encode()
+        self.buffer.extend(data)
+        return len(data)
+
+    def flush(self) -> None:
+        pass
+
+
+def dechunk(data: bytes) -> bytes:
+    out = bytearray()
+    i = 0
+    n = len(data)
+    while i < n:
+
+        j = data.find(b"\r\n", i)
+        if j == -1:
+            break
+        size = int(data[i:j], 16)
+        if size == 0:
+            break
+        out += data[j + 2: j + 2 + size]
+        i = j + 2 + size
+        if i + 1 < n and data[i:i + 2] == b"\r\n":
+            i += 2
+        elif i < n and data[i:i + 1] == b"\n":
+            i += 1
+    return bytes(out)
+
+
+class VirtualHandler:
+
+    def __init__(self) -> None:
+        self.status: int = 200
+        self._headers = []
+        self._chunked = False
+        self.wfile = CapturingWriter()
+
+    def send_response(self, status: int, message=None) -> None:
+        self.status = int(status)
+
+    def send_header(self, keyword: str, value) -> None:
+        self._headers.append((str(keyword).lower(), str(value)))
+
+    def end_headers(self) -> None:
+        self._chunked = any(k == "transfer-encoding" and v.lower() == "chunked"
+                            for k, v in self._headers)
+
+    def log_message(self, fmt: str, *args) -> None:
+        logger.debug("[virtual] " + fmt, *args)
+
+    def header(self, name: str) -> Optional[str]:
+        for k, v in self._headers:
+            if k == name.lower():
+                return v
+        return None
+
+    @property
+    def content_type(self) -> str:
+        return self.header("content-type") or "text/plain"
+
+    def body(self) -> bytes:
+        raw = bytes(self.wfile.buffer)
+        return dechunk(raw) if self._chunked else raw
+
+    def decoded_text(self) -> str:
+        return self.body().decode("utf-8", errors="ignore")
+
+    def parsed_json(self) -> Optional[dict]:
+        try:
+            return json.loads(self.decoded_text())
+        except (ValueError, TypeError):
+            return None
+
+
+TRUNCATION_MARKER = (
+    f"\n[Output truncated: max {MAX_OUTPUT_BYTES} bytes — "
+    f"full output not sent]\n"
+)
+
+
+def analyze_output(text: str) -> dict:
+    meta = {"exit_code": None, "cancelled": False,
+            "timed_out": False, "error": False, "truncated": False}
+    clean = text
+
+    if clean.endswith("\nCancelled\n"):
+        meta["cancelled"] = True
+        clean = clean[:-len("\nCancelled\n")]
+
+    if clean.endswith("\nExit: (process detached)\n"):
+        clean = clean[:-len("\nExit: (process detached)\n")]
+    m = re.search(r"\nExit: (\d+)\n$", clean)
+    if m:
+        meta["exit_code"] = int(m.group(1))
+        clean = clean[:m.start()]
+    if clean.endswith("\nDone\n"):
+        clean = clean[:-len("\nDone\n")]
+    if clean.endswith("\n✅ Done\n"):
+        clean = clean[:-len("\n✅ Done\n")]
+    m = re.search(r"\n❌ Exit code: (\d+)\n$", clean)
+    if m:
+        meta["exit_code"] = int(m.group(1))
+        clean = clean[:m.start()]
+    if re.search(r"\n⏱️ Timed out after \d+s\n$", clean):
+        meta["timed_out"] = True
+        clean = re.sub(r"\n⏱️ Timed out after \d+s\n$", "", clean)
+    for marker in ("\n❌ Error: ", "\nError: "):
+        idx = clean.rfind(marker)
+        if idx != -1:
+            meta["error"] = True
+            clean = clean[:idx]
+            break
+
+    if clean.endswith("\n"):
+        clean = clean[:-1]
+    clean = clean.rstrip("\n")
+    if TRUNCATION_MARKER.strip() in text:
+        meta["truncated"] = True
+    meta["text"] = clean
+    return meta
+
+
+def decode_virtual(vh: VirtualHandler) -> dict:
+    ct = vh.content_type
+    if "json" in ct:
+        data = vh.parsed_json() or {}
+        raw = vh.decoded_text().strip()
+        error = (vh.status >= 400 or bool(data.get("error"))
+                 or data.get("blocked") is True)
+        text = raw
+        if error and not text:
+            text = data.get("error") or f"HTTP {vh.status}"
+        if data.get("requires_confirmation") and not error:
+            text = (raw + "\n\nThis action needs confirmation — re-invoke "
+                    "this tool with `confirmed: true` to proceed.")
+        return {"text": text or "(no output)", "is_error": error}
+    meta = analyze_output(vh.decoded_text())
+    code = meta["exit_code"]
+    is_error = (meta["error"] or meta["timed_out"]
+                or (code is not None and code != 0))
+    return {"text": meta["text"] or "(no output)", "is_error": is_error}
+
+
+WS_ALIAS_DROPS = {"camera", "wifi", "sms", "tts", "ocr"}
+
+
+NATIVE_TOOL_NAMES = {"run", "cancel", "session_start", "session_run",
+                     "session_poll", "session_list", "session_kill"}
+
+
+_INSTANCE_ROUTES = {
+    "ls": "_handle_ls", "read": "_handle_read", "write": "_handle_write",
+    "mkdir": "_handle_mkdir", "delete": "_handle_delete",
+    "search": "_handle_search", "battery": "_handle_battery",
+    "location": "_handle_location", "wifi_info": "_handle_wifi_info",
+    "screenshot": "_handle_screenshot", "camera_photo": "_handle_camera_photo",
+    "notify": "_handle_notify", "sms_send": "_handle_sms_send",
+    "sms_inbox": "_handle_sms_inbox", "tts_speak": "_handle_tts_speak",
+    "open_url": "_handle_open_url", "download": "_handle_download",
+    "public_ip": "_handle_public_ip", "weather": "_handle_weather",
+    "speedtest": "_handle_speedtest", "qrcode": "_handle_qrcode",
+    "image_process": "_handle_image_process",
+    "clipboard_get": "_handle_clipboard_get",
+    "clipboard_set": "_handle_clipboard_set",
+    "toast": "_handle_toast", "share": "_handle_share",
+    "text_extract": "_handle_text_extract",
+}
+
+
+_MODULE_ROUTES = {
+    "system_info": handle_system_info,
+    "health": handle_health,
+    "process_list": handle_process_list,
+    "process_kill": handle_process_kill,
+    "cron_add": handle_cron_add,
+    "cron_list": handle_cron_list,
+    "cron_remove": handle_cron_remove,
+    "cloud_sync": handle_cloud_sync,
+    "diff": handle_diff,
+    "smart_install": handle_smart_install,
+    "diagnose": handle_diagnose,
+    "optimize": handle_optimize,
+    "git_pr": handle_git_pr,
+    "backup": handle_backup,
+    "restore": handle_restore,
+    "recipe_list": handle_recipe_list,
+    "recipe_run": handle_recipe_run,
+    "recipe_save": handle_recipe_save,
+    "context": handle_context,
+    "context_save": handle_context_save,
+    "history": handle_history_list,
+    "history_save": handle_history_save,
+    "history_clear": handle_history_clear,
+}
+
+
+_ghost = None
+
+
+def _bound_method(name: str):
+    global _ghost
+    if _ghost is None:
+        _ghost = MCPHandler.__new__(MCPHandler)
+    return getattr(_ghost, name)
+
+
+def route_callable(tool_name: str):
+    if tool_name in _INSTANCE_ROUTES:
+        return _bound_method(_INSTANCE_ROUTES[tool_name])
+    if tool_name in _MODULE_ROUTES:
+        return _MODULE_ROUTES[tool_name]
+    return None
+
+
+def bridge_tool_names() -> List[str]:
+    return [n for n, _ in _iter_catalog_defs() if n not in NATIVE_TOOL_NAMES]
+
+
+def _iter_catalog_defs():
+    for entry in OPENAI_TOOLS:
+        fn = entry.get("function", entry)
+        name = fn.get("name", "")
+        if not name or name in WS_ALIAS_DROPS:
+            continue
+        params = fn.get("parameters") or {"type": "object", "properties": {}}
+        yield name, {
+            "name": name,
+            "description": fn.get("description", ""),
+            "inputSchema": params,
+        }
+
+
+_EXTRA_TOOL_DEFS = [
+    {
+        "name": "text_extract",
+        "description": "Extract text from an image via OCR (Tesseract).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "input": {"type": "string",
+                          "description": "Image file path"},
+                "lang": {"type": "string",
+                         "description": "OCR language", "default": "eng"},
+            },
+            "required": ["input"],
+        },
+    },
+]
+
+
+EXTRA_NAMES = [d["name"] for d in _EXTRA_TOOL_DEFS]
+
+
+def build_mcp_tool_list(native_defs=None,
+                        filters: tuple = ((), ())) -> List[dict]:
+    by_name = {}
+    for name, d in _iter_catalog_defs():
+        by_name[name] = d
+    for d in _EXTRA_TOOL_DEFS:
+        by_name[d["name"]] = d
+    for d in (native_defs or []):
+        by_name[d["name"]] = d
+
+    includes, excludes = filters
+    ordered = []
+
+    seen = set()
+    for name, d in _iter_catalog_defs():
+        if name not in by_name:
+            continue
+        seen.add(name)
+        ordered.append(by_name[name])
+    for d in list(_EXTRA_TOOL_DEFS) + list(native_defs or []):
+        if d["name"] not in seen:
+            seen.add(d["name"])
+            ordered.append(d)
+
+    def keep(d: dict) -> bool:
+        n = d["name"]
+        if n in excludes:
+            return False
+        return not includes or n in includes
+
+    return [d for d in ordered if keep(d)]
+
+
+def tool_name_allowed(name: str, filters: tuple = ((), ())) -> bool:
+    includes, excludes = filters
+    if name in excludes:
+        return False
+    return not includes or name in includes

--- a/termux_mcp/mcp_config.py
+++ b/termux_mcp/mcp_config.py
@@ -1,0 +1,55 @@
+import os
+
+
+from .config import AUTH_TOKEN as REST_AUTH_TOKEN
+
+
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18",)
+DEFAULT_PROTOCOL_VERSION = "2025-06-18"
+
+
+SERVER_NAME = "termux-native-mcp"
+SERVER_VERSION = "0.10.0"
+
+
+def native_port() -> int:
+    return int(os.environ.get("TERMUX_NATIVE_MCP_PORT", "8081"))
+
+
+def native_host() -> str:
+    return os.environ.get("TERMUX_NATIVE_MCP_HOST", "127.0.0.1")
+
+
+def native_path() -> str:
+    return os.environ.get("TERMUX_NATIVE_MCP_PATH", "/mcp")
+
+
+def native_auth_token() -> str:
+    return os.environ.get("TERMUX_NATIVE_MCP_AUTH_TOKEN") or REST_AUTH_TOKEN
+
+
+def require_auth() -> bool:
+    return bool(native_auth_token())
+
+
+def origin_allowlist() -> list:
+    raw = os.environ.get("TERMUX_NATIVE_MCP_ORIGIN", "")
+    return [v.strip() for v in raw.split(",") if v.strip()]
+
+
+def session_ttl() -> float:
+    return float(os.environ.get("TERMUX_NATIVE_MCP_SESSION_TTL", "1800"))
+
+
+def tools_filter() -> tuple:
+    raw = os.environ.get("TERMUX_NATIVE_MCP_TOOLS", "")
+    includes, excludes = [], []
+    for part in raw.split(","):
+        name = part.strip()
+        if not name:
+            continue
+        if name.startswith("-"):
+            excludes.append(name[1:].strip())
+        else:
+            includes.append(name)
+    return includes, excludes

--- a/termux_mcp/mcp_core.py
+++ b/termux_mcp/mcp_core.py
@@ -1,0 +1,568 @@
+import logging
+import os
+import signal
+import subprocess
+import threading
+import time
+import uuid
+from typing import Callable, Optional
+
+
+from . import mcp_bridge
+from . import mcp_config as cfg
+from .config import COMMAND_TIMEOUT, HOME, MAX_OUTPUT_BYTES
+from .safety import snapshot_targets_from_command
+from .security import get_risk_assessment
+from .shell import preprocess, set_current_dir
+from .utils import shell_quote
+from .websocket import _session_capture, _spawn_auto_input
+
+
+logger = logging.getLogger(__name__)
+
+
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+
+DEFAULT_TMUX_SESSION = "termux-mcp"
+_TRUNCATION_MARKER = (
+    f"\n[Output truncated: max {MAX_OUTPUT_BYTES} bytes — "
+    f"full output not sent]\n"
+)
+
+
+NATIVE_TOOL_DEFS = [
+    {
+        "name": "run",
+        "description": (
+            "Execute a shell command in Termux with streaming output. "
+            "Maintains persistent cd state for this MCP session. Long jobs: "
+            "use session_run/session_poll instead. Risky commands are "
+            "blocked or need confirmed: true."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "cmd": {"type": "string", "description": "Shell command"},
+                "confirmed": {"type": "boolean",
+                              "description": "Acknowledge a risk warning",
+                              "default": False},
+            },
+            "required": ["cmd"],
+        },
+    },
+    {
+        "name": "cancel",
+        "description": "Cancel the command currently running in this session.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "session_start",
+        "description": "Start (or ensure) a persistent tmux session.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session": {"type": "string",
+                            "description": "Session name",
+                            "default": DEFAULT_TMUX_SESSION},
+            },
+        },
+    },
+    {
+        "name": "session_run",
+        "description": (
+            "Run a command in a tmux session WITHOUT blocking — returns "
+            "immediately with initial output; poll with session_poll."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session": {"type": "string",
+                            "description": "Session name",
+                            "default": DEFAULT_TMUX_SESSION},
+                "cmd": {"type": "string",
+                        "description": "Command to run in the session"},
+            },
+            "required": ["cmd"],
+        },
+    },
+    {
+        "name": "session_poll",
+        "description": "Get new output from a running tmux session.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session": {"type": "string",
+                            "description": "Session name",
+                            "default": DEFAULT_TMUX_SESSION},
+            },
+        },
+    },
+    {
+        "name": "session_list",
+        "description": "List live tmux sessions.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "session_kill",
+        "description": "Kill a tmux session.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session": {"type": "string",
+                            "description": "Session name",
+                            "default": DEFAULT_TMUX_SESSION},
+            },
+        },
+    },
+]
+
+
+class RpcError(Exception):
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class MCPSession:
+
+    def __init__(self, sid: str, transport: str) -> None:
+        self.sid = sid
+        self.transport = transport
+        self.cwd = HOME
+        self.created = time.time()
+        self.protocol_version: Optional[str] = None
+        self.lock = threading.Lock()
+        self.killed = threading.Event()
+        self.closed = threading.Event()
+        self.active_pid: Optional[int] = None
+        self.on_line: Optional[Callable[[str], None]] = None
+        self.tmux_seen = {}
+        self.last_used = time.monotonic()
+
+    def touch(self) -> None:
+        self.last_used = time.monotonic()
+
+    def expired(self, ttl: float) -> bool:
+        return time.monotonic() - self.last_used > ttl
+
+    def kill_active(self) -> bool:
+        pid = self.active_pid
+        if pid is None:
+            return False
+        return _kill_process_group(pid)
+
+
+def _kill_process_group(pid: int) -> bool:
+    killpg = getattr(os, "killpg", None)
+    getpgid = getattr(os, "getpgid", None)
+    try:
+        if killpg is not None and getpgid is not None:
+            killpg(getpgid(pid), signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
+_SESSIONS = {}
+_SESSIONS_LOCK = threading.Lock()
+
+
+def create_session(transport: str) -> MCPSession:
+    sid = uuid.uuid4().hex
+    session = MCPSession(sid, transport)
+    with _SESSIONS_LOCK:
+        _SESSIONS[sid] = session
+    return session
+
+
+def get_session(sid: str, touch: bool = True):
+    with _SESSIONS_LOCK:
+        session = _SESSIONS.get(sid)
+        if session is None:
+            return None
+        if session.expired(cfg.session_ttl()):
+            _SESSIONS.pop(sid, None)
+            return None
+    if touch:
+        session.touch()
+    return session
+
+
+def drop_session(sid: str) -> None:
+    with _SESSIONS_LOCK:
+        session = _SESSIONS.pop(sid, None)
+    if session is not None:
+        session.killed.set()
+        session.kill_active()
+        session.closed.set()
+
+
+def active_session_count() -> int:
+    with _SESSIONS_LOCK:
+        return len(_SESSIONS)
+
+
+def server_info() -> dict:
+    return {
+        "protocolVersion": cfg.DEFAULT_PROTOCOL_VERSION,
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": cfg.SERVER_NAME, "version": cfg.SERVER_VERSION},
+        "instructions": (
+            "Termux shell + device tools on this Android device. Commands "
+            "stream output; risky commands are blocked or require "
+            "confirmed:true. Deletes move to ~/termuxGPT/trash and file "
+            "overwrites are snapshotted under ~/termuxGPT/snapshots. "
+            "For long jobs use session_run then session_poll."
+        ),
+    }
+
+
+def negotiate_protocol(client_version) -> str:
+    if client_version in cfg.SUPPORTED_PROTOCOL_VERSIONS:
+        return client_version
+    return cfg.DEFAULT_PROTOCOL_VERSION
+
+
+def _cd_into(session: MCPSession, raw_cmd: str):
+    rest = raw_cmd[2:].strip()
+    path_part, chained = rest, None
+    for sep in (";", "&&"):
+        idx = rest.find(sep)
+        if idx != -1:
+            path_part = rest[:idx].strip()
+            chained = rest[idx + len(sep):].strip()
+            break
+    if not path_part or path_part == "~":
+        session.cwd = HOME
+        return True, HOME, chained
+    raw_path = path_part.replace("~", HOME, 1)
+    new_path = os.path.abspath(
+        raw_path if os.path.isabs(raw_path)
+        else os.path.join(session.cwd, raw_path)
+    )
+    if os.path.isdir(new_path):
+        session.cwd = new_path
+        return True, session.cwd, chained
+    return False, f"Directory not found: {new_path}", None
+
+
+def _notify(session: MCPSession, line: str) -> None:
+    cb = session.on_line
+    if cb is not None:
+        try:
+            cb(line)
+        except Exception:
+            session.on_line = None
+
+
+def _execute_command(session: MCPSession, raw_cmd: str) -> dict:
+    session.killed.clear()
+    process = None
+    watchdog = None
+    sent_bytes = 0
+    truncated = False
+    chunks = []
+
+    def append(text: str) -> None:
+        chunks.append(text)
+        _notify(session, text)
+
+    try:
+        setsid = getattr(os, "setsid", None)
+        kwargs = {"shell": True, "stdout": subprocess.PIPE,
+                  "stderr": subprocess.STDOUT, "stdin": subprocess.PIPE,
+                  "text": True, "cwd": session.cwd}
+        if setsid is not None:
+            kwargs["preexec_fn"] = setsid
+        process = subprocess.Popen(
+            f"export PAGER=cat; {preprocess(raw_cmd)}", **kwargs
+        )
+        session.active_pid = process.pid
+        _spawn_auto_input(process, raw_cmd)
+
+        if COMMAND_TIMEOUT > 0:
+            def _watchdog():
+                try:
+                    process.wait(timeout=COMMAND_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    session.killed.set()
+                    session.kill_active()
+                    try:
+                        process.kill()
+                    except Exception:
+                        pass
+            watchdog = threading.Thread(target=_watchdog, daemon=True)
+            watchdog.start()
+
+        stdout = process.stdout
+        if stdout is None:
+            append("\n❌ Error: no stdout pipe\n")
+            process.wait()
+        for line in stdout or []:
+            if session.killed.is_set():
+                append("\nCancelled\n")
+                break
+            sent_bytes += len(line.encode())
+            if sent_bytes <= MAX_OUTPUT_BYTES:
+                append(line)
+            elif not truncated:
+                truncated = True
+                append(_TRUNCATION_MARKER)
+
+        if watchdog is not None:
+            watchdog.join(timeout=2)
+
+        if not session.killed.is_set():
+            if process.returncode is None:
+                try:
+                    process.wait(timeout=2)
+                except Exception:
+                    pass
+            if process.returncode is None:
+                append("\nExit: (process detached)\n")
+            elif process.returncode == 0:
+                append("\n✅ Done\n")
+            else:
+                append(f"\n❌ Exit code: {process.returncode}\n")
+    except Exception as e:
+        append(f"\n❌ Error: {e}\n")
+    finally:
+        session.active_pid = None
+
+    meta = mcp_bridge.analyze_output("".join(chunks))
+    return {"text": meta["text"], "is_error": _error_from_meta(meta)}
+
+
+def _error_from_meta(meta: dict) -> bool:
+    code = meta["exit_code"]
+    return meta["error"] or meta["timed_out"] or (code not in (None, 0))
+
+
+def _tool_run(session: MCPSession, params: dict) -> dict:
+    p = params or {}
+    cmd = str(p.get("cmd", "")).strip()
+    confirmed = bool(p.get("confirmed", False))
+    if not cmd:
+        return {"text": "Missing 'cmd'", "is_error": True}
+
+    risk = get_risk_assessment(cmd)
+    if risk["blocked"]:
+        return {"text": risk["message"], "is_error": True}
+    if risk["requires_confirmation"] and not confirmed:
+        return {
+            "text": (risk["message"] + "\n\nRe-invoke with `confirmed: true` "
+                     "to proceed."),
+            "is_error": False,
+        }
+
+    snaps = snapshot_targets_from_command(cmd)
+    if snaps and not cmd.startswith("cd"):
+        hint = "; ".join(f"snapshot: {s}" for s in snaps)
+        cmd = f"echo {shell_quote(hint)}; {cmd}"
+    elif snaps:
+        logger.info("Snapshots taken (cd command, not echoed): %s", snaps)
+
+    if cmd.startswith("cd"):
+        ok, msg, chained = _cd_into(session, cmd)
+        if not ok:
+            return {"text": str(msg), "is_error": True}
+        if chained is None:
+            return {"text": str(msg), "is_error": False}
+        return _execute_command(session, chained)
+    return _execute_command(session, cmd)
+
+
+def _tool_cancel(session: MCPSession) -> dict:
+    session.killed.set()
+    ok = session.kill_active()
+    return {"text": ("Cancelled." if ok else "Nothing running."),
+            "is_error": False, "cancelled": ok}
+
+
+def _ensure_tmux(session: MCPSession, name: str) -> None:
+    alive = os.popen(
+        f"tmux has-session -t {name} 2>/dev/null && echo yes || echo no"
+    ).read().strip() == "yes"
+    if not alive:
+        os.system(f"tmux new-session -d -s {name} 2>/dev/null")
+        os.system(f"tmux set-option -t {name} history-limit 20000 2>/dev/null")
+    session.tmux_seen.setdefault(name, 0)
+
+
+def _tool_session(session: MCPSession, name: str, params: dict) -> dict:
+    p = params or {}
+    sess_name = str(p.get("session") or DEFAULT_TMUX_SESSION)
+
+    if name == "session_start":
+        _ensure_tmux(session, sess_name)
+        return {"text": f"Session '{sess_name}' ready.", "is_error": False}
+
+    if name == "session_list":
+        out = os.popen(
+            "tmux list-sessions 2>/dev/null || echo 'No sessions (tmux not installed?)'"
+        ).read().strip()
+        return {"text": out, "is_error": False}
+
+    if name == "session_kill":
+        os.system(f"tmux kill-session -t {sess_name} 2>/dev/null")
+        session.tmux_seen.pop(sess_name, None)
+        return {"text": f"Killed: {sess_name}", "is_error": False}
+
+    if name == "session_run":
+        cmd = str(p.get("cmd", "")).strip()
+        if not cmd:
+            return {"text": "Missing cmd", "is_error": True}
+        _ensure_tmux(session, sess_name)
+        os.system(f"tmux send-keys -t {sess_name} {shell_quote(cmd)} Enter")
+        time.sleep(1.2)
+        seen = session.tmux_seen[sess_name]
+        initial, session.tmux_seen[sess_name] = _session_capture(
+            sess_name, seen)
+        preview = initial.strip()
+        if len(preview) > 2000:
+            preview = preview[-2000:]
+        return {"text": (
+            f"Started in session '{sess_name}':\n{preview or '(no output yet — use session_poll)'}"
+        ), "is_error": False}
+
+    if name == "session_poll":
+        _ensure_tmux(session, sess_name)
+        seen = session.tmux_seen[sess_name]
+        output, session.tmux_seen[sess_name] = _session_capture(
+            sess_name, seen)
+        alive = os.popen(
+            f"tmux has-session -t {sess_name} 2>/dev/null && echo yes || echo no"
+        ).read().strip() == "yes"
+        preview = output.strip()
+        if len(preview) > 4000:
+            preview = preview[-4000:]
+        return {"text": preview or "(no new output)",
+                "is_error": False, "running": alive}
+
+    return {"text": f"Unknown session tool: {name}", "is_error": True}
+
+
+def invoke_tool(session: MCPSession, name: str, params: dict,
+                on_progress=None) -> dict:
+    p = params or {}
+    if not isinstance(p, dict):
+        raise RpcError(INVALID_PARAMS, "Tool arguments must be an object")
+
+    if name == "cancel":
+        return _tool_cancel(session)
+
+    old_cb = session.on_line
+    session.on_line = on_progress
+    try:
+        if name in NATIVE_NAMES:
+            with session.lock:
+                if name == "run":
+                    return _tool_run(session, p)
+                return _tool_session(session, name, p)
+
+        route = mcp_bridge.route_callable(name)
+        if route is None:
+            raise RpcError(INVALID_PARAMS, f"Unknown tool: {name}")
+        with session.lock:
+
+            set_current_dir(session.cwd)
+            vh = mcp_bridge.VirtualHandler()
+            route(vh, p)
+            return mcp_bridge.decode_virtual(vh)
+    finally:
+        session.on_line = old_cb
+
+
+NATIVE_NAMES = frozenset(d["name"] for d in NATIVE_TOOL_DEFS)
+
+
+def tool_list() -> dict:
+    tools = mcp_bridge.build_mcp_tool_list(NATIVE_TOOL_DEFS,
+                                           cfg.tools_filter())
+    return {"tools": tools}
+
+
+def check_tool_allowed(name: str) -> None:
+    if not mcp_bridge.tool_name_allowed(name, cfg.tools_filter()):
+        raise RpcError(INVALID_PARAMS, f"Tool is disabled: {name}")
+
+
+def call_tool(session: MCPSession, name: str, params: dict,
+              on_progress=None) -> dict:
+    if not isinstance(name, str) or not name:
+        raise RpcError(INVALID_PARAMS, "Missing tool name")
+    check_tool_allowed(name)
+    result = invoke_tool(session, name, params, on_progress)
+    content = []
+    text = result.get("text", "")
+    if text:
+        content.append({"type": "text", "text": text})
+    if not content:
+        content.append({"type": "text", "text": "(no output)"})
+    out: dict = {"content": content}
+    if result.get("is_error"):
+        out["isError"] = True
+    for key in ("cancelled", "running"):
+        if key in result:
+            out[key] = result[key]
+    return out
+
+
+def dispatch(session: MCPSession, method: str, params,
+             on_progress=None):
+    if not isinstance(method, str) or not method:
+        raise RpcError(INVALID_REQUEST, "Missing method")
+    session.touch()
+
+    if method == "initialize":
+        client_v = (params or {}).get("protocolVersion") if isinstance(
+            params, dict) else None
+        session.protocol_version = negotiate_protocol(client_v)
+        return server_info()
+    if method == "ping":
+        return {}
+    if method == "tools/list":
+        return tool_list()
+    if method == "tools/call":
+        params = params or {}
+        if not isinstance(params, dict):
+            raise RpcError(INVALID_PARAMS, "Invalid parameters")
+        name = params.get("name")
+        if not isinstance(name, str) or not name:
+            raise RpcError(INVALID_PARAMS, "Missing tool name")
+        args = params.get("arguments", {})
+        if not isinstance(args, dict):
+            raise RpcError(INVALID_PARAMS, "Tool arguments must be an object")
+        progress = None
+        meta = args.get("_meta") if isinstance(args, dict) else None
+        if isinstance(meta, dict) and meta.get("progressToken") is not None:
+            progress = _ProgressProxy(session, meta["progressToken"],
+                                      on_progress)
+        return call_tool(session, name, args, on_progress=progress)
+    if method == "notifications/initialized":
+        return None
+    raise RpcError(METHOD_NOT_FOUND, f"Method not found: {method}")
+
+
+class _ProgressProxy:
+
+    def __init__(self, session, token, emit) -> None:
+        self.session = session
+        self.token = token
+        self.emit = emit
+
+    def __call__(self, line: str) -> None:
+        if self.emit is not None:
+            try:
+                self.emit({"jsonrpc": "2.0", "method": "notifications/progress",
+                           "params": {"progressToken": self.token,
+                                      "progress": 0, "message": line.rstrip()}})
+            except Exception:
+                self.session.on_line = None

--- a/termux_mcp/mcp_main.py
+++ b/termux_mcp/mcp_main.py
@@ -14,7 +14,7 @@ def main(argv=None) -> None:
     parser.add_argument(
         "--stdio", action="store_true",
         help="Speak MCP over stdin/stdout instead of HTTP "
-             "(for Claude Desktop / Cursor via ssh).")
+             "(for desktop MCP clients via ssh).")
     parser.add_argument(
         "--port", type=int, default=None,
         help="HTTP listen port (default: $TERMUX_NATIVE_MCP_PORT or 8081).")

--- a/termux_mcp/mcp_main.py
+++ b/termux_mcp/mcp_main.py
@@ -1,0 +1,34 @@
+import argparse
+
+
+from . import mcp_server
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="termux-native-mcp",
+        description="Native MCP server for Termux (Model Context Protocol, "
+                    "spec 2025-06-18). REST daemon 'termux-mcp' is "
+                    "separate and unaffected.",
+    )
+    parser.add_argument(
+        "--stdio", action="store_true",
+        help="Speak MCP over stdin/stdout instead of HTTP "
+             "(for Claude Desktop / Cursor via ssh).")
+    parser.add_argument(
+        "--port", type=int, default=None,
+        help="HTTP listen port (default: $TERMUX_NATIVE_MCP_PORT or 8081).")
+    parser.add_argument(
+        "--host", type=str, default=None,
+        help="Bind address (default: $TERMUX_NATIVE_MCP_HOST or "
+             "127.0.0.1). Non-loopback requires an auth token.")
+    args = parser.parse_args(argv)
+
+    if args.stdio:
+        mcp_server.run_stdio()
+    else:
+        mcp_server.run_http(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/termux_mcp/mcp_server.py
+++ b/termux_mcp/mcp_server.py
@@ -1,0 +1,77 @@
+import logging
+import sys
+from http.server import HTTPServer
+from socketserver import ThreadingMixIn
+from typing import Optional
+
+
+from . import mcp_config as cfg
+from . import mcp_transport_stdio as stdio
+from .mcp_transport_http import MCPRequestHandler
+from .network import kill_port
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+class MCPHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+def _check_startup_guards(host: str) -> None:
+    if cfg.require_auth() and len(cfg.native_auth_token()) < 16:
+        logger.error(
+            "Auth token is set but too short (< 16 chars). Refusing to "
+            "start for safety."
+        )
+        sys.exit(1)
+    if host not in ("127.0.0.1", "localhost", "::1") and not cfg.require_auth():
+        logger.error(
+            "HOST is set to %s (non-loopback) but no auth token is set. "
+            "Refusing to start. Set TERMUX_NATIVE_MCP_AUTH_TOKEN (or "
+            "TERMUX_MCP_AUTH_TOKEN) or bind to 127.0.0.1.", host,
+        )
+        sys.exit(1)
+
+
+def run_http(host: Optional[str] = None, port: Optional[int] = None) -> None:
+    host = host or cfg.native_host()
+    port = int(port if port is not None else cfg.native_port())
+    _check_startup_guards(host)
+
+    MCPRequestHandler.endpoint = cfg.native_path()
+
+    logger.info("Freeing port %d if occupied...", port)
+    kill_port(port)
+
+    server = MCPHTTPServer((host, port), MCPRequestHandler)
+    if cfg.require_auth():
+        logger.info("Authentication: enabled (length=%d)",
+                    len(cfg.native_auth_token()))
+    logger.info("Termux native MCP (Streamable HTTP) listening on "
+                "http://%s:%d%s", host, port, cfg.native_path())
+    logger.info("REST API (termux-mcp) is a separate process — "
+                "unchanged on its own port.\n")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+        server.server_close()
+        sys.exit(0)
+
+
+def run_stdio() -> None:
+    logger.info("Termux native MCP (stdio) — parent process drives "
+                "stdin/stdout. Nothing on stdout but MCP messages.\n")
+    try:
+        stdio.serve_stdio()
+    except KeyboardInterrupt:
+        pass
+    except BrokenPipeError:
+        pass
+    sys.exit(0)

--- a/termux_mcp/mcp_transport_http.py
+++ b/termux_mcp/mcp_transport_http.py
@@ -1,0 +1,312 @@
+import hmac
+import json
+import logging
+import queue
+import threading
+from http.server import BaseHTTPRequestHandler
+from typing import Optional
+from urllib.parse import urlparse
+
+
+from . import mcp_config as cfg
+from . import mcp_core as core
+
+
+logger = logging.getLogger(__name__)
+
+
+MAX_BODY = 5 * 1024 * 1024
+
+
+MAX_PROGRESS_EVENTS = 200
+
+
+def _auth_ok(token: str) -> bool:
+    expected = cfg.native_auth_token()
+    if not expected:
+        return True
+    if not token:
+        return False
+    return hmac.compare_digest(token.encode(), expected.encode())
+
+
+def _bearer_from(headers) -> str:
+    auth = headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[7:].strip()
+    return ""
+
+
+def _origin_allowed(host: str, origin_header: str) -> bool:
+    if not origin_header:
+        return True
+    allow = cfg.origin_allowlist()
+    if origin_header in allow:
+        return True
+    if not allow:
+        return host in ("127.0.0.1", "localhost", "::1")
+    return False
+
+
+def _envelope_id(msg) -> object:
+    return msg.get("id") if isinstance(msg, dict) else None
+
+
+class MCPRequestHandler(BaseHTTPRequestHandler):
+
+    protocol_version = "HTTP/1.1"
+    endpoint = "/mcp"
+
+    def log_message(self, format, *args) -> None:
+        logger.debug("[MCP-HTTP] " + format, *args)
+
+    def _send_body(self, status: int, data: bytes,
+                   content_type: str = "application/json",
+                   extra: Optional[dict] = None) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        for k, v in (extra or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_json(self, status: int, obj: dict,
+                   extra: Optional[dict] = None) -> None:
+        self._send_body(status, json.dumps(obj).encode(), extra=extra)
+
+    def _send_chunk(self, data: bytes) -> bool:
+        try:
+            self.wfile.write(hex(len(data))[2:].encode() + b"\r\n"
+                             + data + b"\r\n")
+            self.wfile.flush()
+            return True
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return False
+
+    def _finish_chunks(self) -> None:
+        try:
+            self.wfile.write(b"0\r\n\r\n")
+            self.wfile.flush()
+        except Exception:
+            pass
+
+    def _guard(self) -> bool:
+        host = self.headers.get("Host", "127.0.0.1").split(":")[0]
+        if not _origin_allowed(host, self.headers.get("Origin", "")):
+            self._send_json(403, {"error": "Origin not allowed"})
+            return False
+        if not _auth_ok(_bearer_from(self.headers)):
+            self._send_body(401, b'{"error": "Unauthorized"}',
+                            extra={"WWW-Authenticate": "Bearer"})
+            return False
+        path = urlparse(self.path).path
+        if path != self.endpoint:
+            self._send_json(404, {"error": "Not found"})
+            return False
+        return True
+
+    def _read_jsonrpc(self) -> dict:
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        if length > MAX_BODY:
+            return {"_error": core.INVALID_REQUEST,
+                    "message": "Payload too large"}
+        try:
+            raw = self.rfile.read(length)
+            if not raw:
+                return {}
+            msg = json.loads(raw.decode("utf-8"))
+            return msg if isinstance(msg, dict) else {"_bad": True}
+        except Exception:
+            return {"_bad": True}
+
+    def do_OPTIONS(self) -> None:
+
+        self.send_response(204)
+        self.end_headers()
+
+    def do_POST(self) -> None:
+        if not self._guard():
+            return
+        msg = self._read_jsonrpc()
+        if "_bad" in msg:
+            self._send_json(200, self._err(None, core.PARSE_ERROR,
+                                           "Parse error"))
+            return
+        if "_error" in msg:
+            code = msg["_error"]
+            if not isinstance(code, int):
+                code = core.INVALID_REQUEST
+            self._send_json(200, self._err(None, code,
+                                           msg.get("message",
+                                                   "Invalid request")))
+            return
+
+        method = msg.get("method")
+        req_id = _envelope_id(msg)
+        params = msg.get("params") or {}
+        is_request = "id" in msg
+
+        sid = self.headers.get("Mcp-Session-Id", "")
+        session = None
+        if method != "initialize":
+            if not sid:
+                self._send_json(400, self._err(req_id, core.INVALID_REQUEST,
+                                               "Missing Mcp-Session-Id"))
+                return
+            session = core.get_session(sid)
+            if session is None:
+                self._send_json(404, self._err(req_id, core.INVALID_REQUEST,
+                                               "Session expired"))
+                return
+        else:
+            session = core.create_session("http")
+            sid = session.sid
+
+        if not is_request:
+
+            if method in ("notifications/initialized",
+                          "notifications/cancelled"):
+                self._run_dispatch(session, method, params, None)
+            self.send_response(202)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        wants_stream = "text/event-stream" in self.headers.get(
+            "Accept", "")
+        if wants_stream and method == "tools/call":
+            self._stream_call(session, req_id, method, params)
+            return
+
+        try:
+            result = self._run_dispatch(session, method, params, None)
+        except core.RpcError as e:
+            self._send_json(200, self._err(req_id, e.code, str(e)))
+            return
+        except Exception as e:
+            logger.exception("MCP dispatch failed")
+            self._send_json(200, self._err(req_id, core.INTERNAL_ERROR,
+                                           f"Internal error: {e}"))
+            return
+        if result is None:
+            self._send_json(200, self._result(req_id, {}))
+            return
+        extra = {"Mcp-Session-Id": sid} if method == "initialize" else None
+        self._send_json(200, self._result(req_id, result), extra=extra)
+
+    def _stream_call(self, session, req_id, method, params) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        events = queue.Queue(maxsize=256)
+        sent = [0]
+
+        def emit(obj: dict) -> None:
+            if sent[0] >= MAX_PROGRESS_EVENTS:
+                return
+            sent[0] += 1
+            try:
+                events.put_nowait(("data", json.dumps(obj)))
+            except queue.Full:
+                pass
+
+        def worker() -> None:
+            try:
+                result = self._run_dispatch(session, method, params, emit)
+                if result is None:
+                    result = {}
+                events.put(("data", json.dumps(self._result(req_id, result))))
+            except core.RpcError as e:
+                events.put(("data", json.dumps(self._err(req_id, e.code,
+                                                         str(e)))))
+            except Exception as e:
+                logger.exception("MCP streaming call failed")
+                events.put(("data", json.dumps(self._err(
+                    req_id, core.INTERNAL_ERROR, f"Internal error: {e}"))))
+            finally:
+                events.put(("done", None))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+        try:
+            while True:
+                try:
+                    kind, payload = events.get(timeout=15)
+                except queue.Empty:
+                    if not self._send_chunk(b": keepalive\n\n"):
+                        break
+                    continue
+                if kind == "done":
+                    break
+                if not self._send_chunk(f"data: {payload}\n\n".encode()):
+                    break
+        finally:
+            self._finish_chunks()
+
+    def _run_dispatch(self, session, method, params, on_progress):
+        result = core.dispatch(session, method, params,
+                               on_progress=on_progress)
+        if method == "initialize":
+            return result
+        if method == "notifications/cancelled":
+
+            session.killed.set()
+            session.kill_active()
+            return None
+        return result
+
+    def do_GET(self) -> None:
+        if not self._guard():
+            return
+        if "text/event-stream" not in self.headers.get("Accept", ""):
+            self._send_json(405, {"error": "Accept: text/event-stream "
+                                           "required for GET"})
+            return
+        sid = self.headers.get("Mcp-Session-Id", "")
+        session = core.get_session(sid) if sid else None
+        if session is None:
+            self._send_json(404, self._err(None, core.INVALID_REQUEST,
+                                           "Session required for SSE stream"))
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        try:
+            while not session.closed.is_set():
+                if not self._send_chunk(b": keepalive\n\n"):
+                    break
+                session.closed.wait(15)
+        finally:
+            self._finish_chunks()
+            try:
+                self.connection.close()
+            except Exception:
+                pass
+
+    def do_DELETE(self) -> None:
+        if not self._guard():
+            return
+        sid = self.headers.get("Mcp-Session-Id", "")
+        if not sid or core.get_session(sid, touch=False) is None:
+            self._send_json(404, {"error": "Session not found"})
+            return
+        core.drop_session(sid)
+        self._send_json(200, {"ok": True})
+
+    def _result(self, req_id, result: dict) -> dict:
+        return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+    def _err(self, req_id, code: int, message: str) -> dict:
+        return {"jsonrpc": "2.0", "id": req_id,
+                "error": {"code": code, "message": message}}

--- a/termux_mcp/mcp_transport_stdio.py
+++ b/termux_mcp/mcp_transport_stdio.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import sys
+
+
+from . import mcp_core as core
+
+
+logger = logging.getLogger(__name__)
+
+
+SESSION_ID = "stdio"
+
+
+def _result(req_id, result: dict) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _error(req_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id,
+            "error": {"code": code, "message": message}}
+
+
+def _send(out, obj: dict) -> None:
+    out.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    out.flush()
+
+
+def serve_stdio(inp=None, out=None) -> None:
+    inp = inp or sys.stdin
+    out = out or sys.stdout
+    session = None
+
+    print("[termux-native-mcp] stdio transport ready — "
+          "speaking MCP (newline-delimited JSON-RPC)", file=sys.stderr)
+    sys.stderr.flush()
+
+    for raw in inp:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except ValueError:
+            _send(out, _error(None, core.PARSE_ERROR, "Parse error"))
+            continue
+        if not isinstance(msg, dict):
+            _send(out, _error(None, core.INVALID_REQUEST,
+                              "Message must be an object"))
+            continue
+
+        if session is None:
+            session = core.create_session("stdio")
+            session.sid = SESSION_ID
+
+        method = msg.get("method")
+        params = msg.get("params") or {}
+        req_id = msg.get("id")
+        is_request = "id" in msg
+
+        if not isinstance(method, str) or not method:
+            if is_request:
+                _send(out, _error(req_id, core.INVALID_REQUEST,
+                                  "Missing method"))
+            continue
+
+        if method == "initialize":
+            try:
+                res = core.dispatch(session, method, params)
+            except core.RpcError as e:
+                res = None
+                _send(out, _error(req_id, e.code, str(e)))
+            if res is not None and is_request:
+                _send(out, _result(req_id, res))
+            continue
+
+        if not is_request:
+            try:
+                core.dispatch(session, method, params)
+            except core.RpcError as e:
+                logger.warning("notification failed: %s", e)
+            continue
+
+        try:
+            result = core.dispatch(session, method, params)
+        except core.RpcError as e:
+            _send(out, _error(req_id, e.code, str(e)))
+            continue
+        except Exception as e:
+            logger.exception("dispatch failed")
+            _send(out, _error(req_id, core.INTERNAL_ERROR,
+                              f"Internal error: {e}"))
+            continue
+        _send(out, _result(req_id, result if result is not None else {}))
+
+    if session is not None:
+        session.killed.set()
+        session.kill_active()

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -1,0 +1,190 @@
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from termux_mcp import mcp_bridge as bridge
+from termux_mcp import mcp_core as core
+
+
+class DechunkTests(unittest.TestCase):
+    def test_single_frame(self):
+        self.assertEqual(bridge.dechunk(b"4\r\ntest\r\n0\r\n\r\n"), b"test")
+
+    def test_multiple_frames(self):
+        data = b"4\r\ntest\r\n6\r\n world\r\n0\r\n\r\n"
+        self.assertEqual(bridge.dechunk(data), b"test world")
+
+    def test_binary_safe(self):
+        payload = bytes(range(256))
+        frame = hex(256)[2:].encode() + b"\r\n" + payload + b"\r\n0\r\n\r\n"
+        self.assertEqual(bridge.dechunk(frame), payload)
+
+
+class AnalyzeOutputTests(unittest.TestCase):
+    def test_rest_success_marker(self):
+        meta = bridge.analyze_output("hello\n✅ Done\n")
+        self.assertFalse(meta["error"])
+        self.assertIsNone(meta["exit_code"])
+        self.assertEqual(meta["text"], "hello")
+
+    def test_rest_failure_marker(self):
+        meta = bridge.analyze_output("boom\n❌ Exit code: 2\n")
+        self.assertEqual(meta["exit_code"], 2)
+        self.assertEqual(meta["text"], "boom")
+
+    def test_ws_tags(self):
+        ok = bridge.analyze_output("a\nDone\n")
+        self.assertIsNone(ok["exit_code"])
+        err = bridge.analyze_output("a\nExit: 9\n")
+        self.assertEqual(err["exit_code"], 9)
+        det = bridge.analyze_output("a\nExit: (process detached)\n")
+        self.assertIsNone(det["exit_code"])
+
+    def test_cancelled(self):
+        meta = bridge.analyze_output("partial\nCancelled\n")
+        self.assertTrue(meta["cancelled"])
+        self.assertEqual(meta["text"], "partial")
+
+    def test_timeout(self):
+        meta = bridge.analyze_output("stuck\n⏱️ Timed out after 5s\n")
+        self.assertTrue(meta["timed_out"])
+
+    def test_truncation_detected_and_kept(self):
+        text = "a\n" + bridge.TRUNCATION_MARKER.strip() + "\nrest\n✅ Done\n"
+        meta = bridge.analyze_output(text)
+        self.assertTrue(meta["truncated"])
+        self.assertIn("Output truncated", meta["text"])
+
+
+class VirtualHandlerTests(unittest.TestCase):
+    def test_json_capture(self):
+        vh = bridge.VirtualHandler()
+        body = json.dumps({"status": "ok", "cwd": "/home"}).encode()
+        vh.send_response(200)
+        vh.send_header("Content-Type", "application/json")
+        vh.send_header("Content-Length", str(len(body)))
+        vh.end_headers()
+        vh.wfile.write(body)
+        self.assertEqual(vh.status, 200)
+        self.assertEqual(vh.parsed_json(), {"status": "ok", "cwd": "/home"})
+
+    def test_chunked_capture(self):
+        vh = bridge.VirtualHandler()
+        vh.send_response(200)
+        vh.send_header("Content-Type", "text/plain")
+        vh.send_header("Transfer-Encoding", "chunked")
+        vh.end_headers()
+        chunk = b"hi\n"
+        vh.wfile.write(hex(len(chunk))[2:].encode() + b"\r\n"
+                       + chunk + b"\r\n")
+        vh.wfile.write(b"0\r\n\r\n")
+        self.assertEqual(vh.decoded_text(), "hi\n")
+
+    def test_decode_json_confirmation(self):
+        vh = bridge.VirtualHandler()
+        body = json.dumps({"status": "confirmation_required",
+                           "risk_level": "warning",
+                           "requires_confirmation": True}).encode()
+        vh.send_response(200)
+        vh.send_header("Content-Type", "application/json")
+        vh.send_header("Content-Length", str(len(body)))
+        vh.end_headers()
+        vh.wfile.write(body)
+        res = bridge.decode_virtual(vh)
+        self.assertFalse(res["is_error"])
+        self.assertIn("confirmed: true", res["text"])
+
+    def test_decode_json_error(self):
+        vh = bridge.VirtualHandler()
+        body = json.dumps({"error": "Blocked dangerous command: x",
+                           "blocked": True}).encode()
+        vh.send_response(403)
+        vh.send_header("Content-Type", "application/json")
+        vh.send_header("Content-Length", str(len(body)))
+        vh.end_headers()
+        vh.wfile.write(body)
+        res = bridge.decode_virtual(vh)
+        self.assertTrue(res["is_error"])
+
+    def test_decode_stream_markers(self):
+        vh = bridge.VirtualHandler()
+        vh.send_response(200)
+        vh.send_header("Content-Type", "text/plain")
+        vh.send_header("Transfer-Encoding", "chunked")
+        vh.end_headers()
+        chunk = b"all good\n\n\xe2\x9c\x85 Done\n"
+        vh.wfile.write(hex(len(chunk))[2:].encode() + b"\r\n"
+                       + chunk + b"\r\n")
+        vh.wfile.write(b"0\r\n\r\n")
+        res = bridge.decode_virtual(vh)
+        self.assertFalse(res["is_error"])
+        self.assertIn("all good", res["text"])
+
+
+class RegistryTests(unittest.TestCase):
+    def test_names_unique_and_curated(self):
+        tools = bridge.build_mcp_tool_list(core.NATIVE_TOOL_DEFS)
+        names = [t["name"] for t in tools]
+        self.assertEqual(len(names), len(set(names)))
+        self.assertGreater(len(names), 50)
+        self.assertLess(len(names), 70)
+        for alias in ("camera", "wifi", "sms", "tts", "ocr"):
+            self.assertNotIn(alias, names)
+
+    def test_schemas_valid(self):
+        tools = bridge.build_mcp_tool_list(core.NATIVE_TOOL_DEFS)
+        for t in tools:
+            self.assertEqual(t["inputSchema"]["type"], "object", t["name"])
+            props = t["inputSchema"].get("properties", {})
+            for req in t["inputSchema"].get("required", []):
+                self.assertIn(req, props, t["name"])
+            self.assertTrue(t["description"])
+
+    def test_every_bridge_tool_routable(self):
+        for name in bridge.bridge_tool_names():
+            self.assertIsNotNone(bridge.route_callable(name), name)
+
+        ghost = bridge._bound_method(bridge._INSTANCE_ROUTES["ls"])
+        self.assertTrue(callable(ghost))
+
+    def test_native_overrides_catalog(self):
+        tools = bridge.build_mcp_tool_list(core.NATIVE_TOOL_DEFS)
+        runs = [t for t in tools if t["name"] == "run"]
+        self.assertEqual(len(runs), 1)
+        self.assertIn("confirmed", runs[0]["inputSchema"]["properties"])
+
+    def test_extras_included(self):
+        tools = bridge.build_mcp_tool_list(core.NATIVE_TOOL_DEFS)
+        names = [t["name"] for t in tools]
+        self.assertIn("text_extract", names)
+        self.assertIsNotNone(bridge.route_callable("text_extract"))
+
+    def test_filters(self):
+        tools = bridge.build_mcp_tool_list(
+            core.NATIVE_TOOL_DEFS, (["run", "ls"], []))
+        names = [t["name"] for t in tools]
+        self.assertEqual(sorted(names), ["ls", "run"])
+        tools = bridge.build_mcp_tool_list(
+            core.NATIVE_TOOL_DEFS, ([], ["history", "history_save"]))
+        names = [t["name"] for t in tools]
+        self.assertNotIn("history", names)
+
+    def test_env_filter_applied(self):
+        with mock.patch.dict(os.environ,
+                             {"TERMUX_NATIVE_MCP_TOOLS": "run,ls,-history"},
+                             clear=False):
+            tools = core.tool_list()
+            names = [t["name"] for t in tools["tools"]]
+            self.assertIn("run", names)
+            self.assertIn("ls", names)
+            self.assertNotIn("history", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_core.py
+++ b/tests/test_mcp_core.py
@@ -1,0 +1,192 @@
+import io
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from termux_mcp import mcp_core as core
+
+
+def _session():
+    return core.MCPSession("test", "unittest")
+
+
+def _dispatch(session, method, params=None) -> dict:
+    result = core.dispatch(session, method, params)
+    assert result is not None
+    return result
+
+
+class DispatchTests(unittest.TestCase):
+    def test_server_info_shape(self):
+        info = core.server_info()
+        self.assertEqual(info["protocolVersion"], "2025-06-18")
+        self.assertEqual(info["serverInfo"]["name"], "termux-native-mcp")
+        self.assertIn("tools", info["capabilities"])
+
+    def test_negotiate(self):
+        self.assertEqual(core.negotiate_protocol("2025-06-18"), "2025-06-18")
+        self.assertEqual(core.negotiate_protocol("2024-11-05"), "2025-06-18")
+        self.assertEqual(core.negotiate_protocol(None), "2025-06-18")
+
+    def test_dispatch_lifecycle(self):
+        s = _session()
+        res = _dispatch(s, "initialize",
+                        {"protocolVersion": "2025-06-18"})
+        self.assertEqual(s.protocol_version, "2025-06-18")
+        self.assertIn("serverInfo", res)
+        self.assertIsNone(core.dispatch(s, "notifications/initialized", {}))
+        self.assertEqual(core.dispatch(s, "ping", {}), {})
+        listing = _dispatch(s, "tools/list", {})
+        names = [t["name"] for t in listing["tools"]]
+        self.assertIn("run", names)
+        self.assertIn("ls", names)
+
+    def test_unknown_method(self):
+        s = _session()
+        with self.assertRaises(core.RpcError) as ctx:
+            core.dispatch(s, "bogus/method", {})
+        self.assertEqual(ctx.exception.code, core.METHOD_NOT_FOUND)
+
+    def test_missing_tool_name(self):
+        s = _session()
+        with self.assertRaises(core.RpcError) as ctx:
+            core.dispatch(s, "tools/call", {})
+        self.assertEqual(ctx.exception.code, core.INVALID_PARAMS)
+
+    def test_unknown_tool(self):
+        s = _session()
+        with self.assertRaises(core.RpcError) as ctx:
+            core.dispatch(s, "tools/call",
+                          {"name": "no_such_tool", "arguments": {}})
+        self.assertEqual(ctx.exception.code, core.INVALID_PARAMS)
+
+    def test_disabled_tool_by_env(self):
+        s = _session()
+        with mock.patch.dict(os.environ,
+                             {"TERMUX_NATIVE_MCP_TOOLS": "run,ls,-history"},
+                             clear=False):
+            with self.assertRaises(core.RpcError) as ctx:
+                core.dispatch(s, "tools/call",
+                              {"name": "history", "arguments": {}})
+            self.assertIn("disabled", str(ctx.exception))
+
+
+class RiskGateTests(unittest.TestCase):
+
+    def test_blocked_command_is_error(self):
+        s = _session()
+        res = _dispatch(s, "tools/call",
+                        {"name": "run",
+                         "arguments": {"cmd": "rm -rf /"}})
+        self.assertTrue(res.get("isError"))
+        text = res["content"][0]["text"]
+        self.assertIn("Blocked", text)
+
+        res2 = _dispatch(s, "tools/call",
+                         {"name": "run",
+                          "arguments": {"cmd": "rm -rf /",
+                                        "confirmed": True}})
+        self.assertTrue(res2.get("isError"))
+
+    def test_warning_requires_confirmation(self):
+        s = _session()
+        res = _dispatch(s, "tools/call",
+                        {"name": "run",
+                         "arguments": {"cmd": "rm -rf deleteme"}})
+        self.assertFalse(res.get("isError"))
+        self.assertIn("confirmed: true", res["content"][0]["text"])
+
+    def test_missing_cmd(self):
+        s = _session()
+        res = _dispatch(s, "tools/call",
+                        {"name": "run", "arguments": {}})
+        self.assertTrue(res.get("isError"))
+
+    def test_cd_without_chain_is_safe_noop(self):
+        s = _session()
+        res = _dispatch(s, "tools/call",
+                        {"name": "run", "arguments": {"cmd": "cd"}})
+        self.assertFalse(res.get("isError"))
+        self.assertEqual(s.cwd, os.environ.get(
+            "HOME", "/data/data/com.termux/files/home"))
+
+    def test_cd_bad_dir_is_error(self):
+        s = _session()
+        res = _dispatch(s, "tools/call",
+                        {"name": "run",
+                         "arguments": {"cmd": "cd /no/such/dir/9f3a2"}})
+        self.assertTrue(res.get("isError"))
+        self.assertIn("Directory not found", res["content"][0]["text"])
+
+    def test_cancel_idle(self):
+        s = _session()
+        res = _dispatch(s, "tools/call", {"name": "cancel"})
+        self.assertIn("Nothing running", res["content"][0]["text"])
+
+
+class SessionRegistryTests(unittest.TestCase):
+    def test_create_get_drop(self):
+        s = core.create_session("http")
+        self.assertIs(core.get_session(s.sid), s)
+        core.drop_session(s.sid)
+        self.assertIsNone(core.get_session(s.sid))
+        self.assertTrue(s.closed.is_set())
+
+    def test_expiry(self):
+        s = core.create_session("http")
+        s.last_used = 0
+        self.assertIsNone(core.get_session(s.sid))
+        self.assertIsNone(core.get_session(s.sid, touch=False))
+
+
+class StdioLoopTests(unittest.TestCase):
+    def _run_stdio(self, lines):
+        inp = io.StringIO("\n".join(lines) + "\n")
+        out = io.StringIO()
+        with mock.patch("sys.stderr", io.StringIO()):
+            from termux_mcp import mcp_transport_stdio as stdio
+            stdio.serve_stdio(inp=inp, out=out)
+        msgs = [json.loads(l) for l in out.getvalue().splitlines()]
+        return msgs
+
+    def test_initialize_and_list(self):
+        msgs = self._run_stdio([
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                        "params": {"protocolVersion": "2025-06-18"}}),
+            json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+        ])
+        self.assertEqual(len(msgs), 2)
+        self.assertEqual(msgs[0]["id"], 1)
+        self.assertEqual(msgs[0]["result"]["serverInfo"]["name"],
+                         "termux-native-mcp")
+        names = [t["name"] for t in msgs[1]["result"]["tools"]]
+        self.assertIn("run", names)
+
+    def test_notification_no_reply(self):
+        msgs = self._run_stdio([
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+            json.dumps({"jsonrpc": "2.0", "method":
+                        "notifications/initialized"}),
+        ])
+        self.assertEqual(len(msgs), 1)
+
+    def test_bad_json(self):
+        msgs = self._run_stdio(["{not json"])
+        self.assertEqual(msgs[0]["error"]["code"], core.PARSE_ERROR)
+
+    def test_unknown_method_error(self):
+        msgs = self._run_stdio([
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+            json.dumps({"jsonrpc": "2.0", "id": 2, "method": "nope"}),
+        ])
+        self.assertEqual(msgs[1]["error"]["code"], core.METHOD_NOT_FOUND)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -1,0 +1,232 @@
+import http.client
+import json
+import os
+import sys
+import threading
+import unittest
+from typing import Optional
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from termux_mcp import mcp_core as core
+from termux_mcp.mcp_server import MCPHTTPServer
+from termux_mcp.mcp_transport_http import MCPRequestHandler
+
+
+TOKEN = "x" * 24
+
+
+class HTTPTransportTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = MCPHTTPServer(("127.0.0.1", 0), MCPRequestHandler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever,
+                                      daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def tearDown(self):
+        core._SESSIONS.clear()
+
+    def _post(self, body: dict, sid: Optional[str] = None, headers=None,
+              accept=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port,
+                                          timeout=10)
+        hdrs = {"Content-Type": "application/json"}
+        if headers:
+            hdrs.update(headers)
+        if sid:
+            hdrs["Mcp-Session-Id"] = sid
+        if accept:
+            hdrs["Accept"] = accept
+        conn.request("POST", "/mcp", body=json.dumps(body), headers=hdrs)
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        return resp, data
+
+    def test_initialize_issues_session(self):
+        resp, data = self._post({"jsonrpc": "2.0", "id": 1,
+                                 "method": "initialize",
+                                 "params": {"protocolVersion": "2025-06-18"}})
+        self.assertEqual(resp.status, 200)
+        sid = resp.getheader("Mcp-Session-Id")
+        self.assertTrue(sid)
+        msg = json.loads(data)
+        self.assertEqual(msg["id"], 1)
+        self.assertEqual(msg["result"]["serverInfo"]["name"],
+                         "termux-native-mcp")
+        self.assertEqual(msg["result"]["protocolVersion"], "2025-06-18")
+
+    def test_flow_initialize_list_ping_delete(self):
+        _, data = self._post({"jsonrpc": "2.0", "id": 1,
+                              "method": "initialize"})
+        self.assertEqual(json.loads(data)["result"]["serverInfo"]["name"],
+                         "termux-native-mcp")
+        sid = self._last_session()
+        resp, data = self._post({"jsonrpc": "2.0", "id": 2,
+                                 "method": "tools/list"}, sid=sid)
+        self.assertEqual(resp.status, 200)
+        names = [t["name"] for t in json.loads(data)["result"]["tools"]]
+        self.assertIn("run", names)
+        resp, data = self._post({"jsonrpc": "2.0", "id": 3,
+                                 "method": "ping"}, sid=sid)
+        self.assertEqual(json.loads(data)["result"], {})
+        resp, _ = self._delete(sid)
+        self.assertEqual(resp.status, 200)
+
+        resp, _ = self._post({"jsonrpc": "2.0", "id": 4, "method": "ping"},
+                             sid=sid)
+        self.assertEqual(resp.status, 404)
+
+    def _last_session(self):
+        with core._SESSIONS_LOCK:
+            return next(iter(core._SESSIONS))
+
+    def _delete(self, sid):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("DELETE", "/mcp", headers={"Mcp-Session-Id": sid})
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        return resp, data
+
+    def test_session_header_required(self):
+        resp, data = self._post({"jsonrpc": "2.0", "id": 1,
+                                 "method": "ping"})
+        self.assertEqual(resp.status, 400)
+        resp, data = self._post({"jsonrpc": "2.0", "id": 1,
+                                 "method": "ping"}, sid="deadbeef" * 4)
+        self.assertEqual(resp.status, 404)
+
+    def test_notification_returns_202(self):
+        _, _ = self._post({"jsonrpc": "2.0", "id": 1,
+                           "method": "initialize"})
+        sid = self._last_session()
+        resp, data = self._post({"jsonrpc": "2.0",
+                                 "method": "notifications/initialized"},
+                                sid=sid)
+        self.assertEqual(resp.status, 202)
+        self.assertEqual(data, b"")
+
+    def test_unknown_method_jsonrpc_error(self):
+        _, _ = self._post({"jsonrpc": "2.0", "id": 1,
+                           "method": "initialize"})
+        sid = self._last_session()
+        resp, data = self._post({"jsonrpc": "2.0", "id": 2,
+                                 "method": "no/such"}, sid=sid)
+        self.assertEqual(resp.status, 200)
+        msg = json.loads(data)
+        self.assertEqual(msg["error"]["code"], core.METHOD_NOT_FOUND)
+
+    def test_unknown_tool_error(self):
+        _, _ = self._post({"jsonrpc": "2.0", "id": 1,
+                           "method": "initialize"})
+        sid = self._last_session()
+        resp, data = self._post({"jsonrpc": "2.0", "id": 2,
+                                 "method": "tools/call",
+                                 "params": {"name": "ghost_tool",
+                                            "arguments": {}}}, sid=sid)
+        msg = json.loads(data)
+        self.assertEqual(msg["error"]["code"], core.INVALID_PARAMS)
+
+    def test_parse_error(self):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("POST", "/mcp", body=b"{oops",
+                     headers={"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        data = json.loads(resp.read())
+        conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(data["error"]["code"], core.PARSE_ERROR)
+
+    def test_auth_required(self):
+        with mock.patch.dict(os.environ,
+                             {"TERMUX_NATIVE_MCP_AUTH_TOKEN": TOKEN},
+                             clear=False):
+            conn = http.client.HTTPConnection("127.0.0.1", self.port,
+                                              timeout=10)
+            conn.request("POST", "/mcp",
+                         body=json.dumps({"jsonrpc": "2.0", "id": 1,
+                                          "method": "initialize"}),
+                         headers={"Content-Type": "application/json"})
+            resp = conn.getresponse()
+            resp.read()
+            conn.close()
+            self.assertEqual(resp.status, 401)
+
+            resp, data = self._post({"jsonrpc": "2.0", "id": 1,
+                                     "method": "initialize"},
+                                    headers={"Authorization":
+                                             f"Bearer {TOKEN}"})
+            self.assertEqual(resp.status, 200)
+            self.assertTrue(resp.getheader("Mcp-Session-Id"))
+
+    def test_sse_streamed_call(self):
+        _, _ = self._post({"jsonrpc": "2.0", "id": 1,
+                           "method": "initialize"})
+        sid = self._last_session()
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("POST", "/mcp",
+                     body=json.dumps({"jsonrpc": "2.0", "id": 7,
+                                      "method": "tools/call",
+                                      "params": {"name": "cancel",
+                                                 "arguments": {}}}),
+                     headers={"Content-Type": "application/json",
+                              "Accept": "text/event-stream",
+                              "Mcp-Session-Id": sid})
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8")
+        conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.getheader("Content-Type"),
+                         "text/event-stream")
+        data_lines = [l[6:] for l in body.splitlines()
+                      if l.startswith("data: ")]
+        self.assertEqual(len(data_lines), 1)
+        msg = json.loads(data_lines[0])
+        self.assertEqual(msg["id"], 7)
+        self.assertIn("result", msg)
+        self.assertEqual(msg["result"]["content"][0]["text"],
+                         "Nothing running.")
+
+    def test_get_requires_sse_accept(self):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("GET", "/mcp")
+        resp = conn.getresponse()
+        resp.read()
+        conn.close()
+        self.assertEqual(resp.status, 405)
+
+    def test_get_stream_lifecycle(self):
+        _, _ = self._post({"jsonrpc": "2.0", "id": 1,
+                           "method": "initialize"})
+        sid = self._last_session()
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("GET", "/mcp",
+                     headers={"Accept": "text/event-stream",
+                              "Mcp-Session-Id": sid})
+        resp = conn.getresponse()
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.getheader("Content-Type"),
+                         "text/event-stream")
+        first = resp.read1()
+        self.assertIn(b": keepalive", first)
+
+        del_resp, _ = self._delete(sid)
+        self.assertEqual(del_resp.status, 200)
+
+        self.assertEqual(resp.read(), b"")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the native MCP (Model Context Protocol) server support requested in #3.

## Summary

Adds native MCP server support (spec 2025-06-18) as a second command in this package: `termux-native-mcp`. The REST API (`termux-mcp`) is **completely untouched** — both run as separate processes and can run side by side.

```
termux-mcp                  # REST API on 127.0.0.1:8080   (unchanged)
termux-native-mcp           # native MCP, Streamable HTTP on 127.0.0.1:8081
termux-native-mcp --stdio   # native MCP over stdin/stdout (desktop clients)
```

## What you get

* **57 curated tools** (`tools/list`): shell `run` with persistent per-session `cd`, filesystem, device & sensors (termux-api), media, cron, git, smart tools — WS-era duplicate names merged (`camera`→`camera_photo`, `wifi`→`wifi_info`, `sms`→`sms_send`, `tts`→`tts_speak`, `ocr`→`text_extract`)
* **MCP-native tools** for long-running jobs: `cancel` (session-scoped kill — actually works, unlike REST `/cancel` today) and tmux-backed `session_start` / `session_run` / `session_poll` / `session_list` / `session_kill`
* **Streamable HTTP transport**: single `/mcp` endpoint, `Mcp-Session-Id` lifecycle, SSE streams for `tools/call` with `notifications/progress` (capped at 200 events), `DELETE` teardown
* **stdio transport**: newline-delimited JSON-RPC for desktop AI clients

## Safety parity with the REST API

Both servers run the **same handler code**. MCP tool calls dispatch into the existing REST handlers through a capture-only virtual HTTP handler, so every guarantee carries over unchanged: dangerous-command risk gates, the `confirmed: true` confirmation flow, `~/termuxGPT/snapshots` before overwrites, `~/termuxGPT/trash` instead of delete, output caps, auto-`-y` injection.

`run`/`cancel`/`session_*` execute natively with per-session state (own cwd, own pid, kill flag) but call the same primitives the REST handlers use (`get_risk_assessment`, `snapshot_targets_from_command`, `preprocess`).

## Security

* Loopback bind by default; non-loopback binding without a token refuses to start (same rule as REST)
* Bearer auth on every HTTP request — `TERMUX_NATIVE_MCP_AUTH_TOKEN`, falling back to the shared `TERMUX_MCP_AUTH_TOKEN`
* `Origin` validation against `TERMUX_NATIVE_MCP_ORIGIN` (DNS-rebinding guard required by the spec)
* Idle sessions expire (default 30 min); running commands are only killed by `cancel`/`DELETE`/shutdown

## Configuration

| Var / flag | Default | Meaning |
|---|---|---|
| `TERMUX_NATIVE_MCP_PORT` / `--port` | `8081` | HTTP port |
| `TERMUX_NATIVE_MCP_HOST` / `--host` | `127.0.0.1` | bind address |
| `TERMUX_NATIVE_MCP_PATH` | `/mcp` | MCP endpoint path |
| `TERMUX_NATIVE_MCP_TOOLS` | all | tool filter, e.g. `run,ls,-history` |
| `TERMUX_NATIVE_MCP_SESSION_TTL` | `1800` | idle session expiry (seconds) |
| `--stdio` | — | stdio transport instead of HTTP |

## Testing

* 51 new stdlib unittest tests: chunk-decode / output-marker parsing, tool registry integrity, schema validation, risk-gate behavior (no process spawn), session lifecycle, stdio loop, live HTTP transport on an ephemeral port — all green
* CLI smoke-tested end to end (stdio handshake; HTTP initialize → tools/list → cancel → DELETE)
* **Not yet verified**: real shell execution on-device (`run`, `ls`, tmux `session_*`) — run `termux-native-mcp` in Termux and connect RikkaHub before the next release

## Docs

* `docs/mcp.md` — user guide (RikkaHub config JSON, desktop-client stdio sample, env table)
* `docs/mcp-support-design.md` — full audit & design rationale (state model, drift findings, alternatives)
* README gained the "Two commands — which do I run?" section
* Version bumped to **0.10.0** (semver: additive)

## Notes for reviewers

* No existing `.py` module was modified — the REST server is byte-identical to the previous release
* All new files carry the project's AGPL-3.0 license
* Follow-up candidates (separate issues): unify the three executors (REST/WS/MCP) into one runner; fix REST `/cancel` (per-request thread-local pid means it never fires today); give WS `delete`/`write` the same snapshot/trash semantics as REST
